### PR TITLE
IDVA6-1343: Check for non-empty user data before rendering tables

### DIFF
--- a/src/views/manage-users.njk
+++ b/src/views/manage-users.njk
@@ -61,7 +61,7 @@
 
     {% set administratorsTabContent %}
     <h2 class="govuk-heading-l">{{lang.administrators}}</h2>
-    {% if administratorsTableData %}
+    {% if administratorsTableData and administratorsTableData.length > 0 %}
         {{ govukTable({
             caption: lang.administrators,
             captionClasses: "govuk-table__caption--m govuk-visually-hidden",
@@ -77,7 +77,7 @@
 
     {% set standardUsersTabContent %}
     <h2 class="govuk-heading-l">{{lang.standard_users}}</h2>
-    {% if standardUsersTableData %}
+    {% if standardUsersTableData and standardUsersTableData.length > 0 %}
         {{ govukTable({
             caption: lang.standard_users,
             captionClasses: "govuk-table__caption--m govuk-visually-hidden",


### PR DESCRIPTION
Add length checks for administratorsTableData and standardUsersTableData to prevent rendering empty tables in the manage-users view.

![Screenshot 2024-08-01 at 11 36 57](https://github.com/user-attachments/assets/5b89dc79-25ae-4cce-8497-700115e1fb7d)
![Screenshot 2024-08-01 at 11 36 54](https://github.com/user-attachments/assets/0a928b04-f5a1-4e9e-a118-644dd32298db)



