### PR TITLE
IDVA6-1359: Refactor try-adding-user flow and improve test coverage

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,6 +3,7 @@ import { getEnvironmentValue } from "./utils/environmentValue";
 // English and Welsh translation files AND Nunjucks template files for pages
 export const DASHBOARD_PAGE = "dashboard";
 export const MANAGE_USERS_PAGE = "manage-users";
+export const TRY_ADDING_USER = "try-adding-user";
 export const REMOVE_USER_PAGE = "remove-user";
 export const ADD_USER_PAGE = "add-user";
 export const CHECK_MEMBER_DETAILS_PAGE = "check-member-details";
@@ -14,6 +15,7 @@ export const REMOVE_MEMBER_PAGE = "remove-member";
 export const USER_REMOVE_CONFIRMATION_PAGE = "confirmation-member-removed";
 export const MEMBER_ALREADY_REMOVED_PAGE = "member-already-removed";
 export const CONFIRMATION_YOU_ARE_REMOVED = "confirmation-you-are-removed";
+export const PLACEHOLDER_STOP_SCREEN = "placeholder-stop-screen";
 
 // Other Nunjucks template files
 export const SERVICE_UNAVAILABLE_TEMPLATE = "partials/service_unavailable";

--- a/src/locales/cy/translation/try-adding-user.json
+++ b/src/locales/cy/translation/try-adding-user.json
@@ -1,0 +1,7 @@
+{
+    "there_is_a_problem": "[CY] There is a problem",
+    "unable_to_add_user": "[CY] We were unable to add the user to the ACSP at this time.",
+    "what_happens_next": "[CY] What happens next",
+    "error_logged_description": "[CY] We have logged this error and our technical team will investigate. Please try again later.",
+    "return_to_manage_users": "[CY] Return to manage users"
+}

--- a/src/locales/en/translation/try-adding-user.json
+++ b/src/locales/en/translation/try-adding-user.json
@@ -1,0 +1,7 @@
+{
+    "there_is_a_problem": "There is a problem",
+    "unable_to_add_user": "We were unable to add the user to the ACSP at this time.",
+    "what_happens_next": "What happens next",
+    "error_logged_description": "We have logged this error and our technical team will investigate. Please try again later.",
+    "return_to_manage_users": "Return to manage users"
+}

--- a/src/routers/controllers/tryAddingUserController.ts
+++ b/src/routers/controllers/tryAddingUserController.ts
@@ -1,37 +1,61 @@
 import { Request, Response } from "express";
 import * as constants from "../../lib/constants";
+import { PLACEHOLDER_STOP_SCREEN, TRY_ADDING_USER } from "../../lib/constants";
 import logger from "../../lib/Logger";
-import { Error, Errors } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import { AcspMembers, UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import { NewUserDetails } from "../../types/user";
 import { getExtraData } from "../../lib/utils/sessionUtils";
+import { createAcspMembership, getMembershipForLoggedInUser } from "../../services/acspMemberService";
+import { getUserDetails } from "../../services/userAccountService";
+import { getTranslationsForView } from "../../lib/utils/translationUtils";
+import { AnyRecord } from "../../types/utilTypes";
+import { User } from "private-api-sdk-node/dist/services/user-account/types";
 
-export const tryAddingUserControllerGet = async (req: Request, res: Response): Promise<void> => {
+export const tryAddingUserControllerPost = async (req: Request, res: Response): Promise<void> => {
+    const translations = getTranslationsForView(req.t, TRY_ADDING_USER);
+
+    const newUserDetails: NewUserDetails | undefined = getExtraData(req.session, constants.DETAILS_OF_USER_TO_ADD);
+
+    const loggedInUserMembership: AcspMembers = await getMembershipForLoggedInUser(req);
+    const acspNumber: string | null = loggedInUserMembership.items[0]?.acspNumber ?? null;
+    if (!acspNumber) {
+        logger.error(`${tryAddingUserControllerPost.name}: Unable to retrieve ACSP number for the logged-in user`);
+        _renderStopScreen(res, translations);
+        return;
+    }
+
+    if (!newUserDetails?.email) {
+        logger.error(`${tryAddingUserControllerPost.name}: New user details or email not found in session`);
+        throw new Error(`New user details or email not found in session`);
+    }
+
+    const userBeingAdded: User[] = await getUserDetails(newUserDetails.email);
+    if (!userBeingAdded || userBeingAdded.length === 0) {
+        logger.error(`${tryAddingUserControllerPost.name}: User not found. Email: ${newUserDetails.email}`);
+        _renderStopScreen(res, translations);
+        return;
+    }
+
+    const firstUser = userBeingAdded[0] as User;
     try {
-        const newUserDetails: NewUserDetails = getExtraData(req.session, constants.DETAILS_OF_USER_TO_ADD);
-        // call to relevant API once available
-        // but temporarily for testing purposes
-        if (newUserDetails.email === "j.smith@test.com") {
-            const error: Errors = {
-                errors: [
-                    {
-                        error: constants.MEMBER_ALREADY_ADDED_ERROR
-                    } as Error
-                ]
-            };
-            throw error;
-        }
-
+        await createAcspMembership(req, acspNumber, firstUser.userId as string, newUserDetails.userRole as UserRole);
+        logger.info(`${tryAddingUserControllerPost.name}: Successfully added user ${firstUser.userId} to ACSP ${acspNumber}`);
         res.redirect(constants.CONFIRMATION_MEMBER_ADDED_FULL_URL);
     } catch (err: unknown) {
-        const error = err as Errors;
-        logger.debug(`${tryAddingUserControllerGet.name}: request to add a user to ACSP returned an error: ${error.errors[0].error}`);
-
-        // Placeholder error message
-        if (error.errors[0].error === constants.MEMBER_ALREADY_ADDED_ERROR) {
-            res.redirect(constants.MEMBER_ALREADY_ADDED_FULL_URL);
-        } else {
-            throw err;
-        }
-
+        logger.error(`${tryAddingUserControllerPost.name}: Error adding user to ACSP: ${err}`);
+        _renderStopScreen(res, translations);
     }
 };
+
+function _renderStopScreen (res: Response, translations: AnyRecord): void {
+    logger.debug(`${_renderStopScreen.name}: Rendering placeholder stop screen`);
+    res.render(PLACEHOLDER_STOP_SCREEN, {
+        title: translations.there_is_a_problem,
+        message: translations.unable_to_add_user,
+        subheading: translations.what_happens_next,
+        description: translations.error_logged_description,
+        buttonText: translations.return_to_manage_users,
+        buttonHref: constants.MANAGE_USER_FULL_URL,
+        isPlaceholder: true
+    });
+}

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -5,7 +5,7 @@ import { dashboardControllerGet } from "./controllers/dashboardController";
 import { healthCheckController } from "./controllers/healthCheckController";
 import { addUserControllerGet, addUserControllerPost } from "./controllers/addUserController";
 import { checkMemberDetailsControllerGet } from "./controllers/checkMemberDetailsController";
-import { tryAddingUserControllerGet } from "./controllers/tryAddingUserController";
+import { tryAddingUserControllerPost } from "./controllers/tryAddingUserController";
 import { confirmationMemberAddedControllerGet } from "./controllers/confirmationMemberAddedController";
 import { removeUserCheckDetailsControllerGet, removeUserCheckDetailsControllerPost } from "./controllers/removeUserCheckDetailsController";
 import { tryRemovingUserControllerGet } from "./controllers/tryRemovingUserController";
@@ -33,7 +33,7 @@ router.post(constants.ADD_USER_URL, addUserControllerPost);
 
 router.get(constants.CHECK_MEMBER_DETAILS_URL, checkMemberDetailsControllerGet);
 
-router.get(constants.TRY_ADDING_USER_URL, tryAddingUserControllerGet);
+router.post(constants.TRY_ADDING_USER_URL, tryAddingUserControllerPost);
 router.get(constants.TRY_REMOVING_USER_URL, tryRemovingUserControllerGet);
 
 router.get(constants.HEALTHCHECK, healthCheckController);

--- a/src/views/check-member-details.njk
+++ b/src/views/check-member-details.njk
@@ -51,14 +51,15 @@
             })
         }}
 
-        {{ govukButton({
+        <form action="{{ tryAddingUserUrl }}" method="POST">
+            {{ govukButton({
                 text: lang.confirm_and_add_user,
-                href: tryAddingUserUrl,
                 attributes: {
-                    id: "confirm-and-add-user-button"
+                    id: "confirm-and-add-user-button",
+                    type: "submit"
                 }
-            })
-        }}
+            }) }}
+        </form>
 
         <p class="govuk-body">
             <a class="govuk-link" href="{{backLinkUrl}}">{{lang.change_details}}</a>

--- a/src/views/placeholder-stop-screen.njk
+++ b/src/views/placeholder-stop-screen.njk
@@ -1,0 +1,37 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% extends "layouts/default.njk" %}
+
+{% block pageTitle %}
+    {{ title }} - Placeholder
+{% endblock %}
+
+{% block main_content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukWarningText({
+                text: "This is a placeholder page. In production, this should be replaced with a specific error handling page.",
+                iconFallbackText: "Warning"
+            }) }}
+
+            {{ govukErrorSummary({
+                titleText: title,
+                errorList: [
+                    {
+                        text: message
+                    }
+                ]
+            }) }}
+
+            <h2 class="govuk-heading-m">{{ subheading }}</h2>
+            <p class="govuk-body">{{ description }}</p>
+
+            {{ govukButton({
+                text: buttonText,
+                href: buttonHref,
+                classes: "govuk-button--secondary"
+            }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/test/mocks/acsp.members.mock.ts
+++ b/test/mocks/acsp.members.mock.ts
@@ -1,4 +1,72 @@
-import { AcspMembers, UserRole, AcspMembership, UserStatus, MembershipStatus } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import {
+    AcspMembers,
+    AcspMembership,
+    MembershipStatus,
+    UserRole,
+    UserStatus
+} from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import {
+    alanUser,
+    buzzUser,
+    charlieUser,
+    cyclopsUser,
+    dandelionUser,
+    daraUser,
+    davidUser,
+    demoUser,
+    frankieUser,
+    gambitUser,
+    geraltUser,
+    haroldUser,
+    henningUser,
+    jackUser,
+    jimmyUser,
+    jonUser,
+    joUser,
+    karlUser,
+    katherineUser,
+    michaelUser,
+    mickyUser,
+    russellUser,
+    shaunUser,
+    stephenUser,
+    toadieUser,
+    wolverineUser,
+    woodyUser,
+    yenneferUser
+} from "./user.mock";
+
+const generateEtag = () => Math.random().toString(36).substring(2, 15);
+export const createAcspMembershipMock = (
+    id: string,
+    userId: string,
+    userRole: UserRole,
+    acspNumber: string,
+    addedAt: Date,
+    status: MembershipStatus,
+    addedBy?: string,
+    removedAt?: Date,
+    removedBy?: string
+): AcspMembership => ({
+    etag: generateEtag(),
+    id,
+    userId,
+    userDisplayName: `User ${userId}`,
+    userEmail: `user${userId}@example.com`,
+    userRole,
+    acspNumber,
+    acspName: `ACSP ${acspNumber}`,
+    acspStatus: UserStatus.ACTIVE,
+    membershipStatus: status,
+    addedAt: addedAt.toISOString(),
+    addedBy: addedBy || "",
+    removedBy: removedBy || "",
+    removedAt: removedAt ? removedAt.toISOString() : "",
+    kind: "",
+    links: {
+        self: ""
+    }
+});
 
 export const accountOwnerAcspMembership: AcspMembership = {
     etag: "nj3",
@@ -96,3 +164,366 @@ export const getMockAcspMembersResource = (
     totalResults: 3,
     totalPages: 4
 });
+
+// NOTE: All the below is based upon the TestDataManager on the acsp-manage-users-api
+// https://github.com/companieshouse/acsp-manage-users-api/blob/main/src/test/java/uk/gov/companieshouse/acsp/manage/users/common/TestDataManager.java
+export const ToyStoryBuzzAcspMembership: AcspMembership = createAcspMembershipMock(
+    "TS001",
+    buzzUser.userId as string,
+    UserRole.OWNER,
+    "TSA001",
+    new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const ToyStoryWoodyAcspMembership: AcspMembership = createAcspMembershipMock(
+    "TS002",
+    woodyUser.userId as string,
+    UserRole.ADMIN,
+    "TSA001",
+    new Date(Date.now() - 11 * 30 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    buzzUser.userId as string,
+    new Date(Date.now() - 10 * 30 * 24 * 60 * 60 * 1000),
+    buzzUser.userId
+);
+
+export const NetflixBuzzAcspMembership: AcspMembership = createAcspMembershipMock(
+    "NF001",
+    buzzUser.userId as string,
+    UserRole.ADMIN,
+    "NFA001",
+    new Date(Date.now() - 5 * 30 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    woodyUser.userId as string,
+    new Date(Date.now() - 4 * 30 * 24 * 60 * 60 * 1000),
+    woodyUser.userId
+);
+
+export const NetflixWoodyAcspMembership: AcspMembership = createAcspMembershipMock(
+    "NF002",
+    woodyUser.userId as string,
+    UserRole.OWNER,
+    "NFA001",
+    new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const ComedyJimmyAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM001",
+    jimmyUser.userId as string,
+    UserRole.OWNER,
+    "COMA001",
+    new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    undefined,
+    new Date(Date.now() - 8 * 365 * 24 * 60 * 60 * 1000),
+    shaunUser.userId
+);
+
+export const ComedyShaunAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM002",
+    shaunUser.userId as string,
+    UserRole.OWNER,
+    "COMA001",
+    new Date(Date.now() - 9 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const ComedyDavidAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM003",
+    davidUser.userId as string,
+    UserRole.ADMIN,
+    "COMA001",
+    new Date(Date.now() - 8 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    shaunUser.userId as string,
+    new Date(Date.now() - 7 * 365 * 24 * 60 * 60 * 1000),
+    shaunUser.userId
+);
+
+export const ComedyCharlieAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM004",
+    charlieUser.userId as string,
+    UserRole.ADMIN,
+    "COMA001",
+    new Date(Date.now() - 8 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    shaunUser.userId
+);
+
+export const ComedyKatherineAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM005",
+    katherineUser.userId as string,
+    UserRole.ADMIN,
+    "COMA001",
+    new Date(Date.now() - 7 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    charlieUser.userId
+);
+
+export const ComedyRussellAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM006",
+    russellUser.userId as string,
+    UserRole.STANDARD,
+    "COMA001",
+    new Date(Date.now() - 6 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    shaunUser.userId as string,
+    new Date(Date.now() - 5 * 365 * 24 * 60 * 60 * 1000),
+    shaunUser.userId
+);
+
+export const ComedyFrankieAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM007",
+    frankieUser.userId as string,
+    UserRole.STANDARD,
+    "COMA001",
+    new Date(Date.now() - 3 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    shaunUser.userId
+);
+
+export const ComedyMickyAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM008",
+    mickyUser.userId as string,
+    UserRole.STANDARD,
+    "COMA001",
+    new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    charlieUser.userId
+);
+
+export const ComedyStephenAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM009",
+    stephenUser.userId as string,
+    UserRole.OWNER,
+    "COMA001",
+    new Date(Date.now() - 20 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    undefined,
+    new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+    shaunUser.userId
+);
+
+export const ComedyAlanAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM010",
+    alanUser.userId as string,
+    UserRole.OWNER,
+    "COMA001",
+    new Date(Date.now() - 19 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const ComedyDaraAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM011",
+    daraUser.userId as string,
+    UserRole.ADMIN,
+    "COMA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    shaunUser.userId as string,
+    new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+    charlieUser.userId
+);
+
+export const ComedyJackAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM012",
+    jackUser.userId as string,
+    UserRole.ADMIN,
+    "COMA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    shaunUser.userId
+);
+
+export const ComedyJonAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM013",
+    jonUser.userId as string,
+    UserRole.ADMIN,
+    "COMA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    charlieUser.userId
+);
+
+export const ComedyMichealAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM014",
+    michaelUser.userId as string,
+    UserRole.STANDARD,
+    "COMA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.REMOVED,
+    shaunUser.userId as string,
+    new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000),
+    charlieUser.userId
+);
+
+export const ComedyJoAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM015",
+    joUser.userId as string,
+    UserRole.STANDARD,
+    "COMA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    shaunUser.userId
+);
+
+export const ComedyHenningAcspMembership: AcspMembership = createAcspMembershipMock(
+    "COM016",
+    henningUser.userId as string,
+    UserRole.STANDARD,
+    "COMA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    charlieUser.userId
+);
+
+export const WitcherGeraltAcspMembership: AcspMembership = createAcspMembershipMock(
+    "WIT001",
+    geraltUser.userId as string,
+    UserRole.OWNER,
+    "WITA001",
+    new Date(Date.now() - 20 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const WitcherYenneferAcspMembership: AcspMembership = createAcspMembershipMock(
+    "WIT002",
+    yenneferUser.userId as string,
+    UserRole.ADMIN,
+    "WITA001",
+    new Date(Date.now() - 11 * 30 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    geraltUser.userId
+);
+
+export const WitcherDandelionAcspMembership: AcspMembership = createAcspMembershipMock(
+    "WIT003",
+    dandelionUser.userId as string,
+    UserRole.STANDARD,
+    "WITA001",
+    new Date(Date.now() - 10 * 30 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    yenneferUser.userId
+);
+
+export const WitcherDemoAcspMembership: AcspMembership = createAcspMembershipMock(
+    "WIT004",
+    demoUser.userId as string,
+    UserRole.OWNER,
+    "WITA001",
+    new Date(Date.now() - 21 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const NeighboursKarlAcspMembership: AcspMembership = createAcspMembershipMock(
+    "NEI001",
+    karlUser.userId as string,
+    UserRole.OWNER,
+    "NEIA001",
+    new Date(Date.now() - 25 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const NeighboursHaroldAcspMembership: AcspMembership = createAcspMembershipMock(
+    "NEI002",
+    haroldUser.userId as string,
+    UserRole.ADMIN,
+    "NEIA001",
+    new Date(Date.now() - 11 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    karlUser.userId
+);
+
+export const NeighboursToadieAcspMembership: AcspMembership = createAcspMembershipMock(
+    "NEI003",
+    toadieUser.userId as string,
+    UserRole.STANDARD,
+    "NEIA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    haroldUser.userId
+);
+
+export const NeighboursDemoAcspMembership: AcspMembership = createAcspMembershipMock(
+    "NEI004",
+    demoUser.userId as string,
+    UserRole.ADMIN,
+    "NEIA001",
+    new Date(Date.now() - 26 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const XmenWolverineAcspMembership: AcspMembership = createAcspMembershipMock(
+    "XME001",
+    wolverineUser.userId as string,
+    UserRole.OWNER,
+    "XMEA001",
+    new Date(Date.now() - 14 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const XmenCyclopsAcspMembership: AcspMembership = createAcspMembershipMock(
+    "XME002",
+    cyclopsUser.userId as string,
+    UserRole.ADMIN,
+    "XMEA001",
+    new Date(Date.now() - 11 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    wolverineUser.userId
+);
+
+export const XmenGambitAcspMembership: AcspMembership = createAcspMembershipMock(
+    "XME003",
+    gambitUser.userId as string,
+    UserRole.STANDARD,
+    "XMEA001",
+    new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE,
+    cyclopsUser.userId
+);
+
+export const XmenDemoAcspMembership: AcspMembership = createAcspMembershipMock(
+    "XME004",
+    demoUser.userId as string,
+    UserRole.STANDARD,
+    "XMEA001",
+    new Date(Date.now() - 15 * 365 * 24 * 60 * 60 * 1000),
+    MembershipStatus.ACTIVE
+);
+
+export const allAcspMemberships: AcspMembership[] = [
+    ToyStoryBuzzAcspMembership,
+    ToyStoryWoodyAcspMembership,
+    NetflixBuzzAcspMembership,
+    NetflixWoodyAcspMembership,
+    ComedyJimmyAcspMembership,
+    ComedyShaunAcspMembership,
+    ComedyDavidAcspMembership,
+    ComedyCharlieAcspMembership,
+    ComedyKatherineAcspMembership,
+    ComedyRussellAcspMembership,
+    ComedyFrankieAcspMembership,
+    ComedyMickyAcspMembership,
+    ComedyStephenAcspMembership,
+    ComedyAlanAcspMembership,
+    ComedyDaraAcspMembership,
+    ComedyJackAcspMembership,
+    ComedyJonAcspMembership,
+    ComedyMichealAcspMembership,
+    ComedyJoAcspMembership,
+    ComedyHenningAcspMembership,
+    WitcherGeraltAcspMembership,
+    WitcherYenneferAcspMembership,
+    WitcherDandelionAcspMembership,
+    WitcherDemoAcspMembership,
+    NeighboursKarlAcspMembership,
+    NeighboursHaroldAcspMembership,
+    NeighboursToadieAcspMembership,
+    NeighboursDemoAcspMembership,
+    XmenWolverineAcspMembership,
+    XmenCyclopsAcspMembership,
+    XmenGambitAcspMembership,
+    XmenDemoAcspMembership
+];

--- a/test/mocks/user.mock.ts
+++ b/test/mocks/user.mock.ts
@@ -1,6 +1,21 @@
 import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import { NewUserDetails } from "../../src/types/user";
 import { Membership } from "../../src/types/membership";
+import { User } from "private-api-sdk-node/dist/services/user-account/types";
+
+export const createUserMock = (
+    userId: string,
+    email: string,
+    displayName?: string,
+    forename = "",
+    surname = ""
+): User => ({
+    userId,
+    email,
+    displayName,
+    forename,
+    surname
+});
 
 export const userAdamBrownDetails: NewUserDetails = {
     userRole: UserRole.ADMIN,
@@ -35,3 +50,260 @@ export const userJohnSmithRemoveDetails: Membership = {
     acspNumber: "LL0RPG",
     userRole: UserRole.STANDARD
 };
+
+// NOTE: All the below is based upon the TestDataManager on the acsp-manage-users-api
+// https://github.com/companieshouse/acsp-manage-users-api/blob/main/src/test/java/uk/gov/companieshouse/acsp/manage/users/common/TestDataManager.java
+export const buzzUser: User = createUserMock(
+    "TSU001",
+    "buzz.lightyear@toystory.com",
+    undefined,
+    "Buzz",
+    "Lightyear"
+);
+
+export const woodyUser: User = createUserMock(
+    "TSU002",
+    "woody@toystory.com",
+    "Woody",
+    "Woody",
+    ""
+);
+
+export const jimmyUser: User = createUserMock(
+    "COMU001",
+    "jimmy.carr@comedy.com",
+    "Jimmy Carr",
+    "Jimmy",
+    "Carr"
+);
+
+export const shaunUser: User = createUserMock(
+    "COMU002",
+    "shaun.lock@comedy.com",
+    "Shaun Lock",
+    "Shaun",
+    "Lock"
+);
+
+export const davidUser: User = createUserMock(
+    "COMU003",
+    "david.mitchell@comedy.com",
+    "David Mitchell",
+    "David",
+    "Mitchell"
+);
+
+export const charlieUser: User = createUserMock(
+    "COMU004",
+    "charlie.brooker@comedy.com",
+    "Charlie Brooker",
+    "Charlie",
+    "Brooker"
+);
+
+export const katherineUser: User = createUserMock(
+    "COMU005",
+    "kartherine.ryan@comedy.com",
+    "Katherine Ryan",
+    "Katherine",
+    "Ryan"
+);
+
+export const russellUser: User = createUserMock(
+    "COMU006",
+    "russell.brand@comedy.com",
+    "Russell Brand",
+    "Russell",
+    "Brand"
+);
+
+export const frankieUser: User = createUserMock(
+    "COMU007",
+    "frankie.boyle@comedy.com",
+    "Frankie Boyle",
+    "Frankie",
+    "Boyle"
+);
+
+export const mickyUser: User = createUserMock(
+    "COMU008",
+    "micky.flanagan@comedy.com",
+    "Micky Flanagan",
+    "Micky",
+    "Flanagan"
+);
+
+export const stephenUser: User = createUserMock(
+    "COMU009",
+    "stephen.fry@comedy.com",
+    undefined,
+    "Stephen",
+    "Fry"
+);
+
+export const alanUser: User = createUserMock(
+    "COMU010",
+    "alan.davies@comedy.com",
+    undefined,
+    "Alan",
+    "Davies"
+);
+
+export const daraUser: User = createUserMock(
+    "COMU011",
+    "dara.obrien@comedy.com",
+    undefined,
+    "Dara",
+    "O'Brien"
+);
+
+export const jackUser: User = createUserMock(
+    "COMU012",
+    "jack.whitehall@comedy.com",
+    undefined,
+    "Jack",
+    "Whitehall"
+);
+
+export const jonUser: User = createUserMock(
+    "COMU013",
+    "jon.richardson@comedy.com",
+    undefined,
+    "Jon",
+    "Richardson"
+);
+
+export const michaelUser: User = createUserMock(
+    "COMU014",
+    "michael.mcintyre@comedy.com",
+    undefined,
+    "Michael",
+    "McIntyre"
+);
+
+export const joUser: User = createUserMock(
+    "COMU015",
+    "jo.brand@comedy.com",
+    undefined,
+    "Jo",
+    "Brand"
+);
+
+export const henningUser: User = createUserMock(
+    "COMU016",
+    "henning.wehn@comedy.com",
+    undefined,
+    "Henning",
+    "Wehn"
+);
+
+export const geraltUser: User = createUserMock(
+    "WITU001",
+    "geralt@witcher.com",
+    "Geralt of Rivia",
+    "Geralt",
+    "of Rivia"
+);
+
+export const yenneferUser: User = createUserMock(
+    "WITU002",
+    "yennefer@witcher.com",
+    "Yennefer of Vengerberg",
+    "Yennefer",
+    "of Vengerberg"
+);
+
+export const dandelionUser: User = createUserMock(
+    "WITU003",
+    "dandelion@witcher.com",
+    undefined,
+    "Dandelion",
+    ""
+);
+
+export const karlUser: User = createUserMock(
+    "NEIU001",
+    "karl.kennedy@neighbours.com",
+    undefined,
+    "Karl",
+    "Kennedy"
+);
+
+export const haroldUser: User = createUserMock(
+    "NEIU002",
+    "harold.bishop@neighbours.com",
+    "Harold Bishop",
+    "Harold",
+    "Bishop"
+);
+
+export const toadieUser: User = createUserMock(
+    "NEIU003",
+    "toadie@neighbours.com",
+    "Toadie",
+    "Toadie",
+    ""
+);
+
+export const wolverineUser: User = createUserMock(
+    "XMEU001",
+    "wolverine@xmen.com",
+    "Wolverine",
+    "Logan",
+    ""
+);
+
+export const cyclopsUser: User = createUserMock(
+    "XMEU002",
+    "cyclops@xmen.com",
+    undefined,
+    "Scott",
+    "Summers"
+);
+
+export const gambitUser: User = createUserMock(
+    "XMEU003",
+    "gambit@xmen.com",
+    "Gambit",
+    "Remy",
+    "LeBeau"
+);
+
+export const demoUser: User = createUserMock(
+    "67ZeMsvAEgkBWs7tNKacdrPvOmQ",
+    "demo@ch.gov.uk",
+    undefined,
+    "Demo",
+    "User"
+);
+
+export const allUsers: User[] = [
+    buzzUser,
+    woodyUser,
+    jimmyUser,
+    shaunUser,
+    davidUser,
+    charlieUser,
+    katherineUser,
+    russellUser,
+    frankieUser,
+    mickyUser,
+    stephenUser,
+    alanUser,
+    daraUser,
+    jackUser,
+    jonUser,
+    michaelUser,
+    joUser,
+    henningUser,
+    geraltUser,
+    yenneferUser,
+    dandelionUser,
+    karlUser,
+    haroldUser,
+    toadieUser,
+    wolverineUser,
+    cyclopsUser,
+    gambitUser,
+    demoUser
+];

--- a/test/src/routers/controllers/tryAddingUserController.test.ts
+++ b/test/src/routers/controllers/tryAddingUserController.test.ts
@@ -1,12 +1,27 @@
 import mocks from "../../../mocks/all.middleware.mock";
-import { userAdamBrownDetails, userJohnSmithDetails } from "../../../mocks/user.mock";
 import supertest from "supertest";
 import app from "../../../../src/app";
 import { Session } from "@companieshouse/node-session-handler";
 import { NextFunction, Request, Response } from "express";
+import * as acspMemberService from "../../../../src/services/acspMemberService";
+import * as userAccountService from "../../../../src/services/userAccountService";
 import * as constants from "../../../../src/lib/constants";
+import {
+    MembershipStatus,
+    UserRole
+} from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import {
+    createAcspMembershipMock,
+    ToyStoryBuzzAcspMembership,
+    ToyStoryWoodyAcspMembership
+} from "../../../mocks/acsp.members.mock";
+import { buzzUser, woodyUser } from "../../../mocks/user.mock";
+import logger from "../../../../src/lib/Logger";
 
 const session: Session = new Session();
+
+jest.mock("../../../../src/services/acspMemberService");
+jest.mock("../../../../src/services/userAccountService");
 
 mocks.mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
     req.session = session;
@@ -14,44 +29,98 @@ mocks.mockSessionMiddleware.mockImplementation((req: Request, res: Response, nex
 });
 
 const router = supertest(app);
-
 const url = "/authorised-agent/try-adding-user";
 
-describe("GET /authorised-agent/try-adding-user", () => {
+describe("POST /authorised-agent/try-adding-user", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        (acspMemberService.getMembershipForLoggedInUser as jest.Mock).mockResolvedValue({ items: [ToyStoryBuzzAcspMembership] });
+        (userAccountService.getUserDetails as jest.Mock).mockResolvedValue([buzzUser]);
+        (acspMemberService.createAcspMembership as jest.Mock).mockResolvedValue(
+            createAcspMembershipMock(
+                "NEW001",
+                ToyStoryBuzzAcspMembership.userId,
+                UserRole.STANDARD,
+                ToyStoryBuzzAcspMembership.acspNumber,
+                new Date(),
+                MembershipStatus.ACTIVE
+            )
+        );
     });
 
-    it("should check session, user auth and ACSP membership before returning the page", async () => {
-        // Given
-        session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, userAdamBrownDetails);
-        // When
-        await router.get(url);
-        // Then
-        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
-        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-        expect(mocks.mockLoggedUserAcspMembershipMiddleware).toHaveBeenCalled();
+    it("should render stop screen when ACSP number is not found", async () => {
+        (acspMemberService.getMembershipForLoggedInUser as jest.Mock).mockResolvedValue({ items: [] });
+
+        const response = await router.post(url);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain("There is a problem");
+        expect(response.text).toContain("We were unable to add the user to the ACSP at this time.");
     });
 
-    it("should return status 302 and redirect to /authorised-agent/confirmation-member-added", async () => {
-        // Given
-        session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, userAdamBrownDetails);
-        const expectedPageHeading = "Found. Redirecting to /authorised-agent/confirmation-member-added";
-        // When
-        const response = await router.get(url);
-        // Then
-        expect(response.status).toEqual(302);
-        expect(response.text).toContain(expectedPageHeading);
+    it("should log an error when new user details are not found in session", async () => {
+        session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, undefined);
+
+        const loggerSpy = jest.spyOn(logger, "error");
+        await router.post(url);
+
+        expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining("New user details or email not found in session"));
     });
 
-    it("should return status 302 and redirect to /authorised-agent/member-already-added", async () => {
-        // Given
-        session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, userJohnSmithDetails);
-        const expectedPageHeading = "Found. Redirecting to /authorised-agent/member-already-added";
-        // When
-        const response = await router.get(url);
-        // Then
-        expect(response.status).toEqual(302);
-        expect(response.text).toContain(expectedPageHeading);
+    it("should render stop screen when user being added is not found", async () => {
+        session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, {
+            email: "nonexistent@email.com",
+            userRole: UserRole.STANDARD
+        });
+        (userAccountService.getUserDetails as jest.Mock).mockResolvedValue([]);
+
+        const response = await router.post(url);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain("There is a problem");
+        expect(response.text).toContain("We were unable to add the user to the ACSP at this time.");
+    });
+
+    it("should render stop screen when createAcspMembership throws an error", async () => {
+        session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, {
+            email: buzzUser.email,
+            userRole: UserRole.STANDARD
+        });
+        (acspMemberService.createAcspMembership as jest.Mock).mockRejectedValue(new Error("Membership creation failed"));
+
+        const response = await router.post(url);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain("There is a problem");
+        expect(response.text).toContain("We were unable to add the user to the ACSP at this time.");
+    });
+
+    it("should handle adding Woody as a new user", async () => {
+        session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, {
+            email: woodyUser.email,
+            userRole: UserRole.STANDARD
+        });
+        (userAccountService.getUserDetails as jest.Mock).mockResolvedValue([woodyUser]);
+        (acspMemberService.createAcspMembership as jest.Mock).mockResolvedValue(
+            createAcspMembershipMock(
+                "NEW002",
+                ToyStoryWoodyAcspMembership.userId,
+                UserRole.STANDARD,
+                ToyStoryWoodyAcspMembership.acspNumber,
+                new Date(),
+                MembershipStatus.ACTIVE
+            )
+        );
+
+        const response = await router.post(url);
+
+        expect(response.status).toBe(302);
+        expect(response.header.location).toBe(constants.CONFIRMATION_MEMBER_ADDED_FULL_URL);
+        expect(acspMemberService.createAcspMembership).toHaveBeenCalledWith(
+            expect.anything(),
+            ToyStoryWoodyAcspMembership.acspNumber,
+            ToyStoryWoodyAcspMembership.userId,
+            UserRole.STANDARD
+        );
     });
 });


### PR DESCRIPTION
- Convert GET to POST for try-adding-user endpoint
- Implement actual user addition logic in tryAddingUserControllerPost
- Add error handling and stop screen for various failure scenarios
- Update tests to cover new logic and error cases
- Create mock data helpers for ACSP members and users
- Add placeholder stop screen view for error cases
- Update constants and translations for new error handling
- Modify check-member-details view to use POST form submission
- Update router to use new POST controller