### PR TITLE
IDVA6-1428 update i18next middleware config to use session

### DIFF
--- a/src/middleware/i18next.language.ts
+++ b/src/middleware/i18next.language.ts
@@ -1,26 +1,48 @@
-import { Application } from "express";
+import { Application, Request } from "express";
 import i18next, { InitOptions, Resource } from "i18next";
-import * as middleware from "i18next-http-middleware";
+import Middleware from "i18next-http-middleware";
 import requireDir from "require-directory";
 import path from "path";
-
+import { setExtraData, getExtraData } from "../lib/utils/sessionUtils";
 const locales = path.join(__dirname, "/../locales");
+
+const LANG = "lang";
+const supportedLanguages: string[] = ["en", "cy"];
+
 export const enableI18next = (app: Application): void => {
     const resources = requireDir(module, locales) as Resource;
 
     const options: InitOptions = {
-        preload: ["en", "cy"],
+        preload: supportedLanguages,
         resources,
         fallbackLng: "en",
-        supportedLngs: ["en", "cy"],
+        supportedLngs: supportedLanguages,
         detection: {
-            order: ["querystring", "cookie"],
-            caches: ["cookie"],
-            lookupSession: "lang",
-            lookupQuerystring: "lang"
+            order: ["querystring", "detectLangInSession"],
+            caches: ["detectLangInSession"],
+            lookupQuerystring: LANG
         }
     };
 
-    i18next.use(middleware.LanguageDetector).init(options);
-    app.use(middleware.handle(i18next));
+    const customDetector = {
+        name: "detectLangInSession",
+
+        lookup: function (req: Request) {
+            const langInSession: string | undefined = getExtraData(req.session, LANG);
+            if (langInSession && supportedLanguages.includes(langInSession)) {
+                return langInSession;
+            }
+        },
+
+        cacheUserLanguage: function (req: Request) {
+            setExtraData(req.session, LANG, req.language);
+        }
+    };
+
+    const lngDetector = new Middleware.LanguageDetector();
+    lngDetector.addDetector(customDetector);
+
+    i18next.use(lngDetector).init(options);
+
+    app.use(Middleware.handle(i18next));
 };


### PR DESCRIPTION
Link to Jira

https://companieshouse.atlassian.net/browse/IDVA6-1428

Currently the language choice is being saved in a cookie. This PR updates the i18next configuration to both detect and save the user’s preferred language to the session.