### PR TITLE
IDVA6-1433 get logged in user details middleware update

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,6 +55,7 @@ app.use(cookieParser());
 
 app.use(`${constants.LANDING_URL}*`, sessionMiddleware);
 app.use(`${constants.LANDING_URL}*`, authenticationMiddleware);
+app.use(`${constants.LANDING_URL}*`, loggedUserAcspMembershipMiddleware);
 
 // Add i18next middleware
 enableI18next(app);
@@ -63,8 +64,6 @@ app.use((req: Request, res: Response, next: NextFunction) => {
     njk.addGlobal("feedbackSource", req.originalUrl);
     next();
 });
-
-app.use(loggedUserAcspMembershipMiddleware);
 
 // Channel all requests through router dispatch
 routerDispatch(app);

--- a/test/src/routers/router.test.ts
+++ b/test/src/routers/router.test.ts
@@ -16,7 +16,7 @@ describe("GET /dummy", () => {
         await router.get(url);
         expect(mocks.mockSessionMiddleware).not.toHaveBeenCalled();
         expect(mocks.mockAuthenticationMiddleware).not.toHaveBeenCalled();
-        expect(mocks.mockLoggedUserAcspMembershipMiddleware).toHaveBeenCalled();
+        expect(mocks.mockLoggedUserAcspMembershipMiddleware).not.toHaveBeenCalled();
     });
 
     it("should return status 404", async () => {


### PR DESCRIPTION
Link to Jira
https://companieshouse.atlassian.net/browse/IDVA6-1433

We have a middleware function that retrieves ACSP member logged in user details.
Its saves these details to the session so that individual pages do not need to request them.
The PR updates this so that we only fetch the member details on /authorised-agent requests, rather than all requests.