### PR TITLE
IDVA6-1390: Implement language selection functionality

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -7,6 +7,7 @@ $govuk-global-styles: true;
 $govuk-font-url-function: 'custom-url-handler';
 
 @import "node_modules/govuk-frontend/dist/govuk/all";
+@import "./govuk-language-select";
 
 * {
     font-family: "GDS Transport", Arial, sans-serif;

--- a/assets/src/scss/govuk-language-select.scss
+++ b/assets/src/scss/govuk-language-select.scss
@@ -1,0 +1,71 @@
+.govuk-language-select {
+  font-size: 14px;
+  font-size: .875rem;
+  line-height: 1.14286;
+  font-family: GDS Transport,arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-language-select {
+    font-size:16px;
+    font-size: 1rem;
+    line-height: 1.25
+  }
+}
+
+@media print {
+  .govuk-language-select {
+    font-size: 14pt;
+    line-height: 1.2;
+    font-family: sans-serif
+  }
+}
+
+.govuk-language-select:focus {
+  outline: 3px solid transparent;
+  color: #0b0c0c;
+  background-color: #fd0;
+  box-shadow: 0 -2px #fd0,0 4px #0b0c0c;
+  text-decoration: none
+}
+
+.govuk-language-select:active,.govuk-language-select:focus,.govuk-language-select:hover,.govuk-language-select:link,.govuk-language-select:visited {
+  color: #0b0c0c
+}
+
+@media print {
+  .govuk-language-select:active,.govuk-language-select:focus,.govuk-language-select:hover,.govuk-language-select:link,.govuk-language-select:visited {
+    color: #000
+  }
+}
+
+.govuk-language-select:after {
+  content: "";
+  display: block;
+  clear: both
+}
+
+.govuk-language-select__list {
+  margin-top: 1em;
+  float: right;
+  text-align: right
+}
+
+.govuk-language-select__list-item {
+  display: inline-block
+}
+
+.govuk-language-select__list-item:first-child:after {
+  content: "";
+  display: inline-block;
+  position: relative;
+  top: .1875em;
+  height: 1em;
+  border-right: .09375em solid #0b0c0c
+}
+
+.govuk-language-select__list-item [aria-current],.govuk-language-select__list-item a {
+  padding: .3125em
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import "express-async-errors";
-import express, { Request, Response, NextFunction } from "express";
+import express, { NextFunction, Request, Response } from "express";
 import nunjucks from "nunjucks";
 import path from "path";
 import logger from "./lib/Logger";
@@ -13,6 +13,8 @@ import { getTranslationsForView } from "./lib/utils/translationUtils";
 import { httpErrorHandler } from "./routers/controllers/httpErrorController";
 import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import { loggedUserAcspMembershipMiddleware } from "./middleware/loggedUserAcspMembership.middleware";
+import * as url from "node:url";
+import { LANGUAGE_CONFIG } from "./types/language";
 
 const app = express();
 
@@ -61,7 +63,17 @@ app.use(`${constants.LANDING_URL}*`, loggedUserAcspMembershipMiddleware);
 enableI18next(app);
 
 app.use((req: Request, res: Response, next: NextFunction) => {
-    njk.addGlobal("feedbackSource", req.originalUrl);
+    res.locals.locale = req.language as string || LANGUAGE_CONFIG.defaultLanguage;
+    res.locals.languageConfig = LANGUAGE_CONFIG;
+    res.locals.feedbackSource = req.originalUrl;
+    res.locals.addLangToUrl = (lang: string): string => {
+        const parsedUrl = url.parse(req.originalUrl, true);
+        parsedUrl.query.lang = lang;
+        return url.format({
+            pathname: parsedUrl.pathname,
+            query: parsedUrl.query
+        });
+    };
     next();
 });
 

--- a/src/locales/cy/translation/common.json
+++ b/src/locales/cy/translation/common.json
@@ -8,5 +8,6 @@
     "skip_to_main_content": "[CY] Skip to main content",
     "there_is_a_problem": "[CY] There is a problem",
     "title_end": "[CY] - Find and update company information - GOV.UK",
-    "title_error": "[CY] Error: "
+    "title_error": "[CY] Error: ",
+    "language_switcher": "[CY] Language switcher"
 }

--- a/src/locales/en/translation/common.json
+++ b/src/locales/en/translation/common.json
@@ -8,5 +8,6 @@
     "skip_to_main_content": "Skip to main content",
     "there_is_a_problem": "There is a problem",
     "title_end": " - Find and update company information - GOV.UK",
-    "title_error": "Error: "
+    "title_error": "Error: ",
+    "language_switcher": "Language switcher"
 }

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,0 +1,29 @@
+interface LanguageConfig {
+  defaultLanguage: string;
+  supportedLanguages: {
+    [key: string]: {
+      code: string;
+      name: string;
+      nativeName: string;
+      visuallyHiddenText: string;
+    };
+  };
+}
+
+export const LANGUAGE_CONFIG: LanguageConfig = {
+    defaultLanguage: "en",
+    supportedLanguages: {
+        en: {
+            code: "en",
+            name: "English",
+            nativeName: "English",
+            visuallyHiddenText: "Change the language to English"
+        },
+        cy: {
+            code: "cy",
+            name: "Welsh",
+            nativeName: "Cymraeg",
+            visuallyHiddenText: "[CY] Change the language to English"
+        }
+    }
+};

--- a/src/views/partials/nav/top.njk
+++ b/src/views/partials/nav/top.njk
@@ -1,0 +1,16 @@
+<nav class="govuk-language-select" role="navigation" aria-label="{{ lang.language_switcher }}">
+    <ul class="govuk-language-select__list">
+        {% for langCode, langData in languageConfig.supportedLanguages %}
+            <li class="govuk-language-select__list-item">
+                {% if locale == langCode %}
+                    <span aria-current="true">{{ langData.nativeName }}</span>
+                {% else %}
+                    <a href="{{ addLangToUrl(langCode) }}" lang="{{ langCode }}" rel="alternate" class="govuk-link">
+                        <span class="govuk-visually-hidden">{{ langData.visuallyHiddenText }}</span>
+                        <span aria-hidden="true">{{ langData.nativeName }}</span>
+                    </a>
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+</nav>


### PR DESCRIPTION
- Add language selector in top navigation
- Implement language switching logic in Express middleware
- Create LANGUAGE_CONFIG with supported languages (English and Welsh)
- Add SCSS styles for language selector
- Update app.ts to handle language selection and URL modification
- Introduce new type definition for language configuration

This change introduces multi-language support to the application, allowing users to switch between English and Welsh. The language selector is added to the top navigation, and the necessary backend logic is implemented to handle language switching and URL modifications.

![Screenshot 2024-08-15 at 14 02 13](https://github.com/user-attachments/assets/1b438ab3-9856-47eb-8209-beeb4797a401)

![Screenshot 2024-08-15 at 14 02 52](https://github.com/user-attachments/assets/da3513e3-4fe6-4631-a772-a202d01f4a2d)
