### PR TITLE
IDVA6-1436, IDVA6-1435: Improve user flow and data accuracy in member addition process

### DIFF
--- a/src/locales/cy/translation/try-adding-user.json
+++ b/src/locales/cy/translation/try-adding-user.json
@@ -1,6 +1,6 @@
 {
     "service_name": "[CY] Companies House",
-    "cannot_add_user_title": "[CY] You cannot add this user",
+    "cannot_add_user_title": "[CY] You cannot add this user - Find and update company information - GOV.UK",
     "cannot_add_user_heading": "[CY] You cannot add this user",
     "cannot_add_user_paragraph1": "[CY] We have not been able to add the user with the email address you provided.",
     "cannot_add_user_paragraph2": "[CY] This could be because they don't have a Companies House account that uses the email address. Or, they may have already been added to an authorised agent account.",

--- a/src/locales/en/translation/try-adding-user.json
+++ b/src/locales/en/translation/try-adding-user.json
@@ -1,6 +1,6 @@
 {
     "service_name": "Companies House",
-    "cannot_add_user_title": "You cannot add this user",
+    "cannot_add_user_title": "You cannot add this user - Find and update company information - GOV.UK",
     "cannot_add_user_heading": "You cannot add this user",
     "cannot_add_user_paragraph1": "We have not been able to add the user with the email address you provided.",
     "cannot_add_user_paragraph2": "This could be because they don't have a Companies House account that uses the email address. Or, they may have already been added to an authorised agent account.",

--- a/src/routers/controllers/checkMemberDetailsController.ts
+++ b/src/routers/controllers/checkMemberDetailsController.ts
@@ -5,7 +5,7 @@ import { getTranslationsForView } from "../../lib/utils/translationUtils";
 import { getExtraData } from "../../lib/utils/sessionUtils";
 import { getUserRoleTag } from "../../lib/utils/viewUtils";
 import { NewUserDetails } from "../../types/user";
-import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import { AcspMembership, UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 
 export const checkMemberDetailsControllerGet = async (req: Request, res: Response): Promise<void> => {
     const viewData = getViewData(req);
@@ -16,8 +16,9 @@ const getViewData = (req: Request): AnyRecord => {
     const translations = getTranslationsForView(req.t, constants.CHECK_MEMBER_DETAILS_PAGE);
     const newUserDetails: NewUserDetails = getExtraData(req.session, constants.DETAILS_OF_USER_TO_ADD);
     const userRoleTag = getUserRoleTag(newUserDetails.userRole as UserRole, false);
-    // Hardcoded data will be replaced once relevant API calls available
-    const companyName = "MORRIS ACCOUNTING LTD";
+
+    const loggedInUserMembership: AcspMembership = getExtraData(req.session, constants.LOGGED_USER_ACSP_MEMBERSHIP);
+    const companyName = loggedInUserMembership.acspName;
 
     return {
         lang: translations,

--- a/src/routers/controllers/confirmationMemberAddedController.ts
+++ b/src/routers/controllers/confirmationMemberAddedController.ts
@@ -5,7 +5,7 @@ import { AnyRecord } from "types/utilTypes";
 import { getExtraData } from "../../lib/utils/sessionUtils";
 import { NewUserDetails } from "../../types/user";
 import { getUserRoleTag } from "../../lib/utils/viewUtils";
-import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import { AcspMembership, UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 
 export const confirmationMemberAddedControllerGet = async (req: Request, res: Response): Promise<void> => {
     const viewData = getViewData(req);
@@ -18,7 +18,9 @@ const getViewData = (req: Request): AnyRecord => {
     // Hardcoded data will be replaced once relevant API calls available
     const newUserDetails: NewUserDetails = getExtraData(req.session, constants.DETAILS_OF_USER_TO_ADD);
     const userRole = getUserRoleTag(newUserDetails.userRole as UserRole, true);
-    const companyName = "MORRIS ACCOUNTING LTD";
+
+    const loggedInUserMembership: AcspMembership = getExtraData(req.session, constants.LOGGED_USER_ACSP_MEMBERSHIP);
+    const companyName = loggedInUserMembership.acspName;
 
     return {
         lang: translations,

--- a/src/routers/controllers/tryAddingUserController.ts
+++ b/src/routers/controllers/tryAddingUserController.ts
@@ -1,10 +1,13 @@
 import { Request, Response } from "express";
 import * as constants from "../../lib/constants";
 import logger from "../../lib/Logger";
-import { AcspMembers, UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import {
+    AcspMembership,
+    UserRole
+} from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import { NewUserDetails } from "../../types/user";
 import { getExtraData } from "../../lib/utils/sessionUtils";
-import { createAcspMembership, getMembershipForLoggedInUser } from "../../services/acspMemberService";
+import { createAcspMembership } from "../../services/acspMemberService";
 import { getUserDetails } from "../../services/userAccountService";
 import { getTranslationsForView } from "../../lib/utils/translationUtils";
 import { AnyRecord } from "../../types/utilTypes";
@@ -15,11 +18,11 @@ export const tryAddingUserControllerPost = async (req: Request, res: Response): 
 
     const newUserDetails: NewUserDetails | undefined = getExtraData(req.session, constants.DETAILS_OF_USER_TO_ADD);
 
-    const loggedInUserMembership: AcspMembers = await getMembershipForLoggedInUser(req);
-    const { acspNumber, acspName } = loggedInUserMembership.items[0] ?? {};
+    const loggedInUserMembership: AcspMembership = getExtraData(req.session, constants.LOGGED_USER_ACSP_MEMBERSHIP);
+    const { acspNumber, acspName } = loggedInUserMembership ?? {};
     if (!acspNumber || !acspName) {
         logger.error(`${tryAddingUserControllerPost.name}: Unable to retrieve ACSP number or name for the logged-in user`);
-        _renderStopScreen(res, translations, acspName, constants.CHECK_MEMBER_DETAILS_FULL_URL);
+        _renderStopScreen(res, translations, acspName);
         return;
     }
 
@@ -31,7 +34,7 @@ export const tryAddingUserControllerPost = async (req: Request, res: Response): 
     const userBeingAdded: User[] = await getUserDetails(newUserDetails.email);
     if (!userBeingAdded || userBeingAdded.length === 0) {
         logger.error(`${tryAddingUserControllerPost.name}: User not found. Email: ${newUserDetails.email}`);
-        _renderStopScreen(res, translations, acspName, constants.CHECK_MEMBER_DETAILS_FULL_URL);
+        _renderStopScreen(res, translations, acspName);
         return;
     }
 
@@ -42,16 +45,16 @@ export const tryAddingUserControllerPost = async (req: Request, res: Response): 
         res.redirect(constants.CONFIRMATION_MEMBER_ADDED_FULL_URL);
     } catch (err: unknown) {
         logger.error(`${tryAddingUserControllerPost.name}: Error adding user to ACSP: ${err}`);
-        _renderStopScreen(res, translations, acspName, constants.CHECK_MEMBER_DETAILS_FULL_URL);
+        _renderStopScreen(res, translations, acspName);
     }
 };
 
-function _renderStopScreen (res: Response, translations: AnyRecord, acspName: string, backLinkHref: string): void {
+function _renderStopScreen (res: Response, translations: AnyRecord, acspName: string): void {
     logger.debug(`${_renderStopScreen.name}: Rendering cannot add user screen`);
     res.render(constants.CANNOT_ADD_USER, {
         serviceName: translations.service_name,
         title: translations.cannot_add_user_title,
-        backLinkHref: backLinkHref,
+        backLinkUrl: constants.CHECK_MEMBER_DETAILS_FULL_URL,
         manageUsersLinkText: `${translations.manage_users_link_text} ${acspName}.`,
         manageUsersLinkHref: constants.MANAGE_USER_FULL_URL,
         lang: translations

--- a/test/src/routers/controllers/addUserController.test.ts
+++ b/test/src/routers/controllers/addUserController.test.ts
@@ -7,6 +7,10 @@ import { Session } from "@companieshouse/node-session-handler";
 import { NextFunction, Request, Response } from "express";
 import * as userAccountService from "../../../../src/services/userAccountService";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
+import {
+    administratorAcspMembership,
+    loggedAccountOwnerAcspMembership, ToyStoryBuzzAcspMembership
+} from "../../../mocks/acsp.members.mock";
 
 const router = supertest(app);
 const url = "/authorised-agent/add-user";
@@ -25,6 +29,7 @@ describe(`GET ${url}`, () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        session.setExtraData(constants.LOGGED_USER_ACSP_MEMBERSHIP, loggedAccountOwnerAcspMembership);
     });
 
     it("should check session and user auth before returning the page", async () => {
@@ -52,7 +57,7 @@ describe(`GET ${url}`, () => {
 
     it("should display page content - form information and administrator and standard user radio buttons for selecting role if administrator logged in", async () => {
         // Given
-        sessionUtilsSpy.mockReturnValue("demo2@ch.gov.uk");
+        session.setExtraData(constants.LOGGED_USER_ACSP_MEMBERSHIP, administratorAcspMembership);
         // When
         const encodedResponse = await router.get(url);
         expect(encodedResponse.status).toEqual(200);
@@ -101,6 +106,7 @@ describe(`POST ${url}`, () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        session.setExtraData(constants.LOGGED_USER_ACSP_MEMBERSHIP, ToyStoryBuzzAcspMembership);
     });
 
     it("should check session, user auth and ACSP membership before routing to controller", async () => {
@@ -136,7 +142,6 @@ describe(`POST ${url}`, () => {
     it("should redirect to the no account page when form inputs valid but no user details found", async () => {
         mockUserAccService.mockResolvedValueOnce([]);
         const response = await router.post(url).send({ email: "bob@bob.com", userRole: "standard" });
-        expect(response.status).toEqual(302);
-        expect(response.header.location).toEqual(constants.PLACEHOLDER_CREATE_CH_ACC_FULL_URL);
+        expect(response.status).toEqual(200);
     });
 });

--- a/test/src/routers/controllers/checkMemberDetailsController.test.ts
+++ b/test/src/routers/controllers/checkMemberDetailsController.test.ts
@@ -7,6 +7,7 @@ import { NextFunction, Request, Response } from "express";
 import * as constants from "../../../../src/lib/constants";
 import * as en from "../../../../src/locales/en/translation/check-member-details.json";
 import { UserRoleTag } from "../../../../src/types/userRoleTag";
+import { loggedAccountOwnerAcspMembership } from "../../../mocks/acsp.members.mock";
 
 const session: Session = new Session();
 
@@ -37,6 +38,7 @@ describe("GET /authorised-agent/check-member-details", () => {
     it("should return status 200", async () => {
         // Given
         session.setExtraData(constants.DETAILS_OF_USER_TO_ADD, userAdamBrownDetails);
+        session.setExtraData(constants.LOGGED_USER_ACSP_MEMBERSHIP, loggedAccountOwnerAcspMembership);
         const expectedUserRoleTag = UserRoleTag.ADMIN;
         // When
         const response = await router.get(url);

--- a/test/src/routers/controllers/confirmationMemberAdded.test.ts
+++ b/test/src/routers/controllers/confirmationMemberAdded.test.ts
@@ -9,13 +9,14 @@ import { NewUserDetails } from "../../../../src/types/user";
 import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
+import { loggedAccountOwnerAcspMembership } from "../../../mocks/acsp.members.mock";
 
 const router = supertest(app);
 
 const session: Session = new Session();
 
 const url = "/authorised-agent/confirmation-member-added";
-const companyName = "MORRIS ACCOUNTING LTD";
+const companyName = loggedAccountOwnerAcspMembership.acspName;
 
 const userRole: UserRole = UserRole.STANDARD;
 const userDetails: NewUserDetails = { userRole: userRole, userId: "12345", isValid: true, email: "test@example.com" };
@@ -30,6 +31,7 @@ describe("GET /authorised-agent/confirmation-member-added", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        session.setExtraData(constants.LOGGED_USER_ACSP_MEMBERSHIP, loggedAccountOwnerAcspMembership);
     });
 
     it("should check session, user auth and ACSP membership before returning the page", async () => {

--- a/test/src/routers/controllers/tryAddingUserController.test.ts
+++ b/test/src/routers/controllers/tryAddingUserController.test.ts
@@ -11,7 +11,7 @@ import {
     UserRole
 } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import {
-    createAcspMembershipMock,
+    createAcspMembershipMock, loggedAccountOwnerAcspMembership,
     ToyStoryBuzzAcspMembership,
     ToyStoryWoodyAcspMembership
 } from "../../../mocks/acsp.members.mock";
@@ -34,7 +34,6 @@ const url = "/authorised-agent/try-adding-user";
 describe("POST /authorised-agent/try-adding-user", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        (acspMemberService.getMembershipForLoggedInUser as jest.Mock).mockResolvedValue({ items: [ToyStoryBuzzAcspMembership] });
         (userAccountService.getUserDetails as jest.Mock).mockResolvedValue([buzzUser]);
         (acspMemberService.createAcspMembership as jest.Mock).mockResolvedValue(
             createAcspMembershipMock(
@@ -46,10 +45,11 @@ describe("POST /authorised-agent/try-adding-user", () => {
                 MembershipStatus.ACTIVE
             )
         );
+        session.setExtraData(constants.LOGGED_USER_ACSP_MEMBERSHIP, ToyStoryBuzzAcspMembership);
     });
 
     it("should render stop screen when ACSP number is not found", async () => {
-        (acspMemberService.getMembershipForLoggedInUser as jest.Mock).mockResolvedValue({ items: [] });
+        session.setExtraData(constants.LOGGED_USER_ACSP_MEMBERSHIP, undefined);
 
         const response = await router.post(url);
 


### PR DESCRIPTION
- Update page title for "You cannot add this user" page
- Fix back link on "Cannot add user" page to return to Check Details page
- Redirect users without CH accounts to stop page instead of placeholder
- Replace hardcoded ACSP names with dynamic `acspName` from user membership
- Remove hardcoded user roles, use actual roles from ACSP membership
- Refactor to use ACSP membership data consistently across controllers
- Update tests to reflect these changes

This change addresses issues raised in IDVA6-1436 and IDVA6-1431, improving the user experience and data accuracy when adding new members to an ACSP. It ensures correct page navigation, displays appropriate error messages, and uses real ACSP and user data instead of hardcoded values.