### PR TITLE
IDVA6-1405: Adding Matomo Analytics For Manage User Page

### DIFF
--- a/src/lib/utils/viewUtils.ts
+++ b/src/lib/utils/viewUtils.ts
@@ -3,7 +3,7 @@ import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/t
 import { UserRoleTag } from "../../types/userRoleTag";
 
 export const getLink = (href: string, displayText: string): string => {
-    return `<a href="${href}">${displayText}</a>`;
+    return `<a data-event-id="remove" href="${href}">${displayText}</a>`;
 };
 
 export const getHiddenText = (hiddenText: string): string => {

--- a/src/views/manage-users.njk
+++ b/src/views/manage-users.njk
@@ -21,7 +21,8 @@
             text: lang.add_a_user,
             href: addUserUrl,
             attributes: {
-                id: "add-a-user-button"
+                id: "add-a-user-button",
+                "data-event-id": "add-a-user"
             }
         }) }}
 
@@ -141,6 +142,9 @@
                     id: accountOwnersTabId,
                     panel: {
                         html: accountOwnersTabContent
+                    },
+                    attributes: {
+                        "data-event-id": "account-owner-tab"
                     }
                 },
                 {
@@ -148,6 +152,9 @@
                     id: administratorsTabId,
                     panel: {
                         html: administratorsTabContent
+                    },
+                      attributes: {
+                        "data-event-id": "admin-user-tab"
                     }
                 },
                 {
@@ -155,6 +162,9 @@
                     id: standardUsersTabId,
                     panel: {
                         html: standardUsersTabContent
+                    },
+                     attributes: {
+                        "data-event-id": "standard-user-tab"
                     }
                 }
             ]

--- a/test/src/lib/utils/viewUtils.test.ts
+++ b/test/src/lib/utils/viewUtils.test.ts
@@ -7,7 +7,7 @@ describe("getLink", () => {
         // Given
         const href = "/unit/test";
         const displayText = "Click me";
-        const expectedLink = "<a href=\"/unit/test\">Click me</a>";
+        const expectedLink = "<a data-event-id=\"remove\" href=\"/unit/test\">Click me</a>";
         // When
         const result = getLink(href, displayText);
         // Then

--- a/test/src/routers/controllers/manageUsersController.getViewData.test.ts
+++ b/test/src/routers/controllers/manageUsersController.getViewData.test.ts
@@ -37,7 +37,7 @@ describe("manageUsersController - getViewData", () => {
                 { text: "james.morris@gmail.com" },
                 { text: "Not Provided" },
                 {
-                    html: "<a href=\"/authorised-agent/remove-member/JGyB\">Remove <span class=\"govuk-visually-hidden\">james.morris@gmail.com</span></a>"
+                    html: "<a data-event-id=\"remove\" href=\"/authorised-agent/remove-member/JGyB\">Remove <span class=\"govuk-visually-hidden\">james.morris@gmail.com</span></a>"
                 }
 
             ]],
@@ -46,7 +46,7 @@ describe("manageUsersController - getViewData", () => {
                 { text: "jane.doe@gmail.com" },
                 { text: "Not Provided" },
                 {
-                    html: "<a href=\"/authorised-agent/remove-member/WSC838\">Remove <span class=\"govuk-visually-hidden\">jane.doe@gmail.com</span></a>"
+                    html: "<a data-event-id=\"remove\" href=\"/authorised-agent/remove-member/WSC838\">Remove <span class=\"govuk-visually-hidden\">jane.doe@gmail.com</span></a>"
                 }
 
             ]],
@@ -55,7 +55,7 @@ describe("manageUsersController - getViewData", () => {
                 { text: "jeremy.lloris@gmail.com" },
                 { text: "Not Provided" },
                 {
-                    html: "<a href=\"/authorised-agent/remove-member/ABC123\">Remove <span class=\"govuk-visually-hidden\">jeremy.lloris@gmail.com</span></a>"
+                    html: "<a data-event-id=\"remove\" href=\"/authorised-agent/remove-member/ABC123\">Remove <span class=\"govuk-visually-hidden\">jeremy.lloris@gmail.com</span></a>"
                 }
 
             ]],


### PR DESCRIPTION
**Changes made:**

Adding Matomo Analytics for:
- Add a user
- Remove
- Account owner Tab
- Administrator Tab
- Standard User Tab
- updated tests

Link to ticket: https://companieshouse.atlassian.net/browse/IDVA6-1405