### PR TITLE
IDVA6-1461: Add "Success" title to notification banners

### DIFF
--- a/src/locales/cy/translation/common.json
+++ b/src/locales/cy/translation/common.json
@@ -26,6 +26,7 @@
     "reject_analytics_cookies": "[CY] Reject analytics cookies",
     "rejected_analytics_cookies": "[CY] You've rejected analytics cookies.",
     "skip_to_main_content": "[CY] Skip to main content",
+    "success": "[CY] Success",
     "tell_us_what_you_think_of_companies_house": "[CY] Tell us what you think of Companies House",
     "tell_us_what_you_think_of_this_service": "[CY] Tell us what you think of this service",
     "there_is_a_problem": "[CY] There is a problem",

--- a/src/locales/en/translation/common.json
+++ b/src/locales/en/translation/common.json
@@ -26,6 +26,7 @@
     "reject_analytics_cookies": "Reject analytics cookies",
     "rejected_analytics_cookies": "You've rejected analytics cookies.",
     "skip_to_main_content": "Skip to main content",
+    "success": "Success",
     "tell_us_what_you_think_of_companies_house": "Tell us what you think of Companies House",
     "tell_us_what_you_think_of_this_service": "Tell us what you think of this service",
     "there_is_a_problem": "There is a problem",

--- a/src/views/confirmation-member-added.njk
+++ b/src/views/confirmation-member-added.njk
@@ -21,8 +21,9 @@
   <div class="govuk-grid-column-two-thirds">
 
     {{ govukNotificationBanner({
-         html: bannerHtml,
-        type: "success"
+        html: bannerHtml,
+        type: "success",
+        titleText: lang.success
     }) }}
 
     <span class="govuk-caption-l">{{companyName}}</span>

--- a/src/views/confirmation-member-removed.njk
+++ b/src/views/confirmation-member-removed.njk
@@ -18,7 +18,8 @@
     
     {{ govukNotificationBanner({
         html: bannerHtml,
-        type: "success"
+        type: "success",
+        titleText: lang.success
     }) }}
 
     <span class="govuk-caption-l">{{companyName}}</span>

--- a/src/views/confirmation-you-are-removed.njk
+++ b/src/views/confirmation-you-are-removed.njk
@@ -18,7 +18,8 @@
     
     {{ govukNotificationBanner({
         html: bannerHtml,
-        type: "success"
+        type: "success",
+        titleText: lang.success
     }) }}
 
     <span class="govuk-caption-l">{{companyName}}</span>


### PR DESCRIPTION
- Add "success" string to English and Welsh translation files
- Update notification banners in member addition/removal confirmations
- Set "Success" as the title for these notification banners (translated)