### PR TITLE
IDVA6-1501: Centralize 'back_link' in common.json and remove duplicates

### DIFF
--- a/src/locales/cy/translation/cannot-add-user.json
+++ b/src/locales/cy/translation/cannot-add-user.json
@@ -1,6 +1,4 @@
 {
-    "back_link": "[CY] Back",
-    "back_link_to_the_previous_page": "[CY] Backlink to the previous page",
     "cannot_add_user_heading": "[CY] You cannot add this user",
     "cannot_add_user_paragraph1": "[CY] We have not been able to add the user with the email address you provided.",
     "cannot_add_user_paragraph2": "[CY] This could be because they don't have a Companies House account that uses the email address. Or, they may have already been added to an authorised agent account.",

--- a/src/locales/cy/translation/check-member-details.json
+++ b/src/locales/cy/translation/check-member-details.json
@@ -1,5 +1,4 @@
 {
-    "back_link": "[CY] Back",
     "change_details": "[CY] Change details",
     "confirm_and_add_user": "[CY] Confirm and add user",
     "page_header": "[CY] Check the details before you add the user",

--- a/src/locales/cy/translation/common.json
+++ b/src/locales/cy/translation/common.json
@@ -4,6 +4,7 @@
     "accessibility_statement": "[CY] Accessibility statement",
     "all_content_available": "[CY] All content is available under the",
     "at_any_time": "[CY] at any time.",
+    "back_link": "[CY] Back",
     "back_link_to_the_previous_page": "[CY] Backlink to the previous page",
     "built_by": "[CY] Built by",
     "cancel": "[CY] Cancel",

--- a/src/locales/cy/translation/stop-page-add-account-owner.json
+++ b/src/locales/cy/translation/stop-page-add-account-owner.json
@@ -1,6 +1,5 @@
 {
     "add_acc_owner_btn": "[CY] Add an account owner",
-    "back_link": "[CY] Back",
     "before_you_remove": "[CY]  before you remove yourself from the account.",
     "details": {
         "p1": "[CY] Account owners receive essential emails with information about the authorised agent account.",

--- a/src/locales/en/translation/cannot-add-user.json
+++ b/src/locales/en/translation/cannot-add-user.json
@@ -1,6 +1,4 @@
 {
-    "back_link": "Back",
-    "back_link_to_the_previous_page": "Backlink to the previous page",
     "cannot_add_user_heading": "You cannot add this user",
     "cannot_add_user_paragraph1": "We have not been able to add the user with the email address you provided.",
     "cannot_add_user_paragraph2": "This could be because they don't have a Companies House account that uses the email address. Or, they may have already been added to an authorised agent account.",

--- a/src/locales/en/translation/check-member-details.json
+++ b/src/locales/en/translation/check-member-details.json
@@ -1,5 +1,4 @@
 {
-    "back_link": "Back",
     "change_details": "Change details",
     "confirm_and_add_user": "Confirm and add user",
     "page_header": "Check the details before you add the user",

--- a/src/locales/en/translation/common.json
+++ b/src/locales/en/translation/common.json
@@ -4,6 +4,7 @@
     "accessibility_statement": "Accessibility statement",
     "all_content_available": "All content is available under the",
     "at_any_time": "at any time.",
+    "back_link": "Back",
     "back_link_to_the_previous_page": "Backlink to the previous page",
     "built_by": "Built by",
     "cancel": "Cancel",

--- a/src/locales/en/translation/stop-page-add-account-owner.json
+++ b/src/locales/en/translation/stop-page-add-account-owner.json
@@ -1,6 +1,5 @@
 {
     "add_acc_owner_btn": "Add an account owner",
-    "back_link": "Back",
     "before_you_remove": " before you remove yourself from the account.",
     "details": {
         "p1": "Account owners receive essential emails with information about the authorised agent account.",

--- a/test/src/routers/controllers/cannotAddUserController.test.ts
+++ b/test/src/routers/controllers/cannotAddUserController.test.ts
@@ -5,6 +5,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { NextFunction, Request, Response } from "express";
 import * as constants from "../../../../src/lib/constants";
 import * as en from "../../../../src/locales/en/translation/cannot-add-user.json";
+import * as enCommon from "../../../../src/locales/en/translation/common.json";
 import { loggedAccountOwnerAcspMembership } from "../../../mocks/acsp.members.mock";
 
 const session: Session = new Session();
@@ -38,7 +39,7 @@ describe("GET /authorised-agent/cannot-add-user", () => {
         expect(response.text).toContain(en.cannot_add_user_title);
         expect(response.text).toContain(en.cannot_add_user_heading);
         expect(response.text).toContain(en.cannot_add_user_paragraph1);
-        expect(response.text).toContain(en.back_link);
+        expect(response.text).toContain(enCommon.back_link);
         expect(response.text).toContain(constants.CHECK_MEMBER_DETAILS_FULL_URL);
         expect(response.text).toContain(constants.MANAGE_USERS_FULL_URL);
         expect(response.text).toContain(loggedAccountOwnerAcspMembership.acspName);

--- a/test/src/routers/controllers/checkMemberDetailsController.test.ts
+++ b/test/src/routers/controllers/checkMemberDetailsController.test.ts
@@ -6,6 +6,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { NextFunction, Request, Response } from "express";
 import * as constants from "../../../../src/lib/constants";
 import * as en from "../../../../src/locales/en/translation/check-member-details.json";
+import * as enCommon from "../../../../src/locales/en/translation/common.json";
 import { UserRoleTagEn } from "../../../../src/types/userRoleTagEn";
 import { loggedAccountOwnerAcspMembership } from "../../../mocks/acsp.members.mock";
 
@@ -44,7 +45,7 @@ describe("GET /authorised-agent/check-member-details", () => {
         const response = await router.get(url);
         // Then
         expect(response.status).toEqual(200);
-        expect(response.text).toContain(en.back_link);
+        expect(response.text).toContain(enCommon.back_link);
         expect(response.text).toContain(en.change_details);
         expect(response.text).toContain(en.confirm_and_add_user);
         expect(response.text).toContain(en.page_header);


### PR DESCRIPTION
- Added 'back_link' to common.json in both English and Welsh translations
- Removed redundant 'back_link' entries from: (already present in common.json)
  - check-member-details.json
  - cannot-add-user.json
  - stop-page-add-account-owner.json
- Removed redundant 'back_link_to_the_previous_page' from cannot-add-user.json (already present in common.json)

This change improves maintainability by centralizing common translations and reducing duplication across JSON files. The 'back_link' text will now be sourced from common.json and can be overridden in specific views if needed.  There is no need to override if it's the same value, so those have been removed.