### PR TITLE
IDVA6-1518: Fix multiple bugs

### DIFF
--- a/src/routers/controllers/manageUsersController.ts
+++ b/src/routers/controllers/manageUsersController.ts
@@ -70,7 +70,8 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
         accountOwnersTabId: constants.ACCOUNT_OWNERS_ID,
         administratorsTabId: constants.ADMINISTRATORS_ID,
         standardUsersTabId: constants.STANDARD_USERS_ID,
-        templateName: constants.MANAGE_USERS_PAGE
+        templateName: constants.MANAGE_USERS_PAGE,
+        manageUsersTabId: activeTabId
     };
 
     let foundUser: AcspMembership[] = [];
@@ -95,26 +96,24 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
                     text: errorMessage
                 }
             };
-            ownerMembers = (await getAcspMemberships(req, acspNumber, false, 0, 10000, [UserRole.OWNER])).items;
-            adminMembers = (await getAcspMemberships(req, acspNumber, false, 0, 10000, [UserRole.ADMIN])).items;
-            standardMembers = (await getAcspMemberships(req, acspNumber, false, 0, 10000, [UserRole.STANDARD])).items;
+            pageNumbers.ownerPage = 1;
+            pageNumbers.adminPage = 1;
+            pageNumbers.standardPage = 1;
         }
         viewData.search = search;
-    } else {
-        const ownerMemberRawViewData = await getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.OWNER, constants.ACCOUNT_OWNERS_TAB_ID, translations);
-        ownerMembers = ownerMemberRawViewData.memberships;
-        viewData.accoutOwnerPadinationData = ownerMemberRawViewData.pagination;
-
-        const adminMemberRawViewData = await getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.ADMIN, constants.ADMINISTRATORS_TAB_ID, translations);
-        adminMembers = adminMemberRawViewData.memberships;
-        viewData.adminPadinationData = adminMemberRawViewData.pagination;
-
-        const standardMemberRawViewData = await getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.STANDARD, constants.STANDARD_USERS_TAB_ID, translations);
-        standardMembers = standardMemberRawViewData.memberships;
-        viewData.standardUserPadinationData = standardMemberRawViewData.pagination;
-
-        viewData.manageUsersTabId = activeTabId;
     }
+
+    const ownerMemberRawViewData = await getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.OWNER, constants.ACCOUNT_OWNERS_TAB_ID, translations);
+    ownerMembers = ownerMemberRawViewData.memberships;
+    viewData.accoutOwnerPadinationData = ownerMemberRawViewData.pagination;
+
+    const adminMemberRawViewData = await getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.ADMIN, constants.ADMINISTRATORS_TAB_ID, translations);
+    adminMembers = adminMemberRawViewData.memberships;
+    viewData.adminPadinationData = adminMemberRawViewData.pagination;
+
+    const standardMemberRawViewData = await getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.STANDARD, constants.STANDARD_USERS_TAB_ID, translations);
+    standardMembers = standardMemberRawViewData.memberships;
+    viewData.standardUserPadinationData = standardMemberRawViewData.pagination;
 
     const title = getTitle(translations, userRole, !!errorMessage);
     viewData.title = title;

--- a/src/views/add-user.njk
+++ b/src/views/add-user.njk
@@ -91,7 +91,7 @@
                     {{lang.option_1_hint_p}}
                 </p>
 
-                <ul class="govuk-body">
+                <ul class="govuk-body govuk-list govuk-list--bullet">
                     <li>{{ lang.option_1_hint_bullet_1 }}</li>
                     <li>{{ lang.option_1_hint_bullet_2 }}</li>
                     <li>{{ lang.option_1_hint_bullet_3 }}</li>
@@ -102,7 +102,7 @@
                 <p class="govuk-body">
                     {{lang.option_2_hint_p}}
                 </p>
-                <ul class="govuk-body">
+                <ul class="govuk-body govuk-list govuk-list--bullet">
                     <li>{{ lang.option_2_hint_bullet_1 }}</li>
                     <li>{{ lang.option_2_hint_bullet_2 }}</li>
                 </ul>

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -85,7 +85,7 @@
             if ("{{errors}}" !== "") {
                 history.pushState(null, document.title, location.pathname + location.search);
                 window.scrollTo(0, 0);
-            } else {
+            } else if (window.location.search) {
                 let element = document.getElementById("{{manageUsersTabId}}".substring(4))
                 if (element) {
                     element.scrollIntoView();

--- a/src/views/partials/__header.njk
+++ b/src/views/partials/__header.njk
@@ -19,7 +19,7 @@
 
         <div class="govuk-header__content">
             <a href="/" class="govuk-header__link govuk-header__service-name">
-                {{lang.find_and_update_company_information_header}}
+                {{lang.find_and_update_company_information}}
             </a>
         </div>
     </div>

--- a/test/src/routers/controllers/manageUsersController.search.test.ts
+++ b/test/src/routers/controllers/manageUsersController.search.test.ts
@@ -55,8 +55,8 @@ describe("manageUsersControllerGet - search", () => {
         // Then
         expect(response.text).toContain(accountOwnerAcspMembership.userEmail);
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
-        expect(response.text).toContain(en.you_have_no_admin_users);
-        expect(response.text).toContain(en.you_have_no_standard_users);
+        expect(response.text).not.toContain(en.you_have_no_admin_users);
+        expect(response.text).not.toContain(en.you_have_no_standard_users);
         expect(response.text).not.toContain(en.you_have_no_account_owners_users);
     });
 
@@ -71,8 +71,8 @@ describe("manageUsersControllerGet - search", () => {
         expect(response.text).toContain(administratorAcspMembership.userEmail);
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
         expect(response.text).not.toContain(en.you_have_no_admin_users);
-        expect(response.text).toContain(en.you_have_no_standard_users);
-        expect(response.text).toContain(en.you_have_no_account_owners_users);
+        expect(response.text).not.toContain(en.you_have_no_standard_users);
+        expect(response.text).not.toContain(en.you_have_no_account_owners_users);
     });
 
     it("should return an expected response if search string is a valid email address that has standard user ACSP membership", async () => {
@@ -85,9 +85,9 @@ describe("manageUsersControllerGet - search", () => {
         // Then
         expect(response.text).toContain(standardUserAcspMembership.userEmail);
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
-        expect(response.text).toContain(en.you_have_no_admin_users);
+        expect(response.text).not.toContain(en.you_have_no_admin_users);
         expect(response.text).not.toContain(en.you_have_no_standard_users);
-        expect(response.text).toContain(en.you_have_no_account_owners_users);
+        expect(response.text).not.toContain(en.you_have_no_account_owners_users);
     });
 
     it("should return nothing if search string is a valid email address that has no ACSP membership", async () => {
@@ -99,9 +99,9 @@ describe("manageUsersControllerGet - search", () => {
         const response = await router.get(`${url}?search=${search}`);
         // Then
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
-        expect(response.text).toContain(en.you_have_no_admin_users);
-        expect(response.text).toContain(en.you_have_no_standard_users);
-        expect(response.text).toContain(en.you_have_no_account_owners_users);
+        expect(response.text).not.toContain(en.you_have_no_admin_users);
+        expect(response.text).not.toContain(en.you_have_no_standard_users);
+        expect(response.text).not.toContain(en.you_have_no_account_owners_users);
     });
 });
 


### PR DESCRIPTION
- Ensures pagination still works upon a search failure, we default to page 1
  - We also ensure normal results show when a search fails, rather than we have "no" "admin/owner/standard"
  - Note, a valid search should only have 1 result, so no need for pagination there
- Fix bullet point styling on add user page (just adding some classes)
- Ensure the header/title of the page shows, it was referencing the wrong translation

https://companieshouse.atlassian.net/browse/IDVA6-1518

Edit: pushed https://github.com/companieshouse/acsp-manage-users-web/pull/97/commits/eebf8f6234a4a33563c99b14dc5da6b259dcebeb to handle scenario where we scroll when the page loads initially