### PR TITLE
IDVA6-1572: Tools dir and acsp data seeding tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,4 @@
+# This folder holds various tools used utility, testing, etc.
+
+
+

--- a/tools/seed-acsp-data-mongo/README.md
+++ b/tools/seed-acsp-data-mongo/README.md
@@ -1,0 +1,56 @@
+# MongoDB Test Data Generator
+
+Adds users, an ACSP and ACSP member data to MongoDB.
+
+## Setup and Usage
+
+1. In the project directory, install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Run the script:
+   ```bash
+   node index.js
+   ```
+
+## Environment Options
+
+Use the `USE_ENV` variable to specify the MongoDB configuration:
+
+```bash
+USE_ENV=cidev node index.js
+```
+
+Pre-configured environments:
+- `local` (default): Uses localhost MongoDB
+- `phoenix`: Uses Phoenix development MongoDB
+- `cidev`: Uses CI development MongoDB
+
+## Custom Environment Variables
+
+You can customize the script using these environment variables:
+
+- `MONGODB_URI`: Override the MongoDB connection string
+- `DEFAULT_PASSWORD`: Set a custom default password for generated users (default: "password")
+- `NO_USERS_TO_CREATE`: Specify the number of users to generate (default: 100)
+
+Example usage:
+```bash
+USE_ENV=pheonix NO_USERS_TO_CREATE=50 DEFAULT_PASSWORD=custompass node index.js
+```
+
+## Configuration
+
+The `config.js` file contains pre-configured MongoDB URIs and default values. You can modify this file to add or change environments and default settings. Here's an example of how to add a new environment:
+
+```diff
+const mongodbConfigs = {
+    local: "mongodb://localhost:27017",
+    phoenix: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?...",
+    cidev: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?...",
++   staging: "mongodb+srv://staging_user@staging-cluster.example.net/admin?..."
+};
+```
+
+Environment variables will override the values in `config.js` when provided.

--- a/tools/seed-acsp-data-mongo/config.js
+++ b/tools/seed-acsp-data-mongo/config.js
@@ -1,0 +1,11 @@
+const mongodbConfigs = {
+    local: "mongodb://localhost:27017",
+    phoenix: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?retryWrites=true&loadBalanced=false&replicaSet=atlas-yar7m5-shard-0&readPreference=primary&srvServiceName=mongodb&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-1&3t.uriVersion=3&3t.connection.name=pheonix&3t.databases=admin&3t.alwaysShowAuthDB=true&3t.alwaysShowDBFromUserRole=true&3t.sslTlsVersion=TLS",
+    cidev: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?retryWrites=true&loadBalanced=false&replicaSet=atlas-yar7m5-shard-0&readPreference=primary&srvServiceName=mongodb&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-1&3t.uriVersion=3&3t.connection.name=pheonix&3t.databases=admin&3t.alwaysShowAuthDB=true&3t.alwaysShowDBFromUserRole=true&3t.sslTlsVersion=TLS"
+};
+
+const USE_ENV = process.env.USE_ENV || "local";
+
+export const MONGODB_URI = process.env.MONGODB_URI || mongodbConfigs[USE_ENV];
+export const DEFAULT_PASSWORD = process.env.DEFAULT_PASSWORD || "password";
+export const NO_USERS_TO_CREATE = process.env.NO_USERS_TO_CREATE ? parseInt(process.env.NO_USERS_TO_CREATE, 10) : 100;

--- a/tools/seed-acsp-data-mongo/config.js
+++ b/tools/seed-acsp-data-mongo/config.js
@@ -1,7 +1,7 @@
 const mongodbConfigs = {
     local: "mongodb://localhost:27017",
-    phoenix: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?retryWrites=true&loadBalanced=false&replicaSet=atlas-yar7m5-shard-0&readPreference=primary&srvServiceName=mongodb&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-1&3t.uriVersion=3&3t.connection.name=pheonix&3t.databases=admin&3t.alwaysShowAuthDB=true&3t.alwaysShowDBFromUserRole=true&3t.sslTlsVersion=TLS",
-    cidev: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?retryWrites=true&loadBalanced=false&replicaSet=atlas-yar7m5-shard-0&readPreference=primary&srvServiceName=mongodb&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-1&3t.uriVersion=3&3t.connection.name=pheonix&3t.databases=admin&3t.alwaysShowAuthDB=true&3t.alwaysShowDBFromUserRole=true&3t.sslTlsVersion=TLS"
+    phoenix: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?retryWrites=true&loadBalanced=false&replicaSet=atlas-yar7m5-shard-0&readPreference=primary&srvServiceName=mongodb&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-1",
+    cidev: "mongodb+srv://phoenix_dev@phoenix-dev-pl-0.ueium.mongodb.net/admin?retryWrites=true&loadBalanced=false&replicaSet=atlas-yar7m5-shard-0&readPreference=primary&srvServiceName=mongodb&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-1"
 };
 
 const USE_ENV = process.env.USE_ENV || "local";

--- a/tools/seed-acsp-data-mongo/index.js
+++ b/tools/seed-acsp-data-mongo/index.js
@@ -1,0 +1,130 @@
+import { DEFAULT_PASSWORD, MONGODB_URI, NO_USERS_TO_CREATE } from "./config.js";
+import { faker } from "@faker-js/faker";
+import { MongoClient } from "mongodb";
+
+async function main () {
+    const client = new MongoClient(MONGODB_URI, { directConnection: true });
+
+    try {
+        await client.connect();
+        await listDatabases(client);
+
+        // create data for users
+        const users = createUserData(NO_USERS_TO_CREATE);
+        // create a single ACSP
+        const acsp = createAcspData(1);
+        // create member data for the users and the above newly created ACSP
+        const acspMembers = createAcspMemberData(acsp[0], users);
+
+        await addUserDataToMongo(client, users);
+        await addAcspDataToMongo(client, acsp);
+        await addAcspMemberDataToMongo(client, acspMembers);
+    } catch (e) {
+        console.error(e);
+    } finally {
+        await client.close();
+    }
+}
+
+async function listDatabases (client) {
+    const databasesList = await client.db().admin().listDatabases();
+
+    console.log("Databases:");
+    databasesList.databases.forEach((db) => console.log(` - ${db.name}`));
+}
+
+async function addUserDataToMongo (client, newUsers) {
+    const result = await client
+        .db("account")
+        .collection("users")
+        .insertMany(newUsers);
+
+    console.log(
+        `${result.insertedCount} new users(s) created with the following ids:`
+    );
+    console.log(result.insertedIds);
+}
+
+async function addAcspDataToMongo (client, acsp) {
+    const result = await client
+        .db("acsp_profile")
+        .collection("acsp_profile")
+        .insertMany(acsp);
+
+    console.log(
+        `${result.insertedCount} new acsp(s) created with the following ids:`
+    );
+    console.log(result.insertedIds);
+}
+
+async function addAcspMemberDataToMongo (client, acspMembers) {
+    const result = await client
+        .db("acsp_members")
+        .collection("acsp_members")
+        .insertMany(acspMembers);
+
+    console.log(
+        `${result.insertedCount} new acsp members created with the following ids:`
+    );
+    console.log(result.insertedIds);
+}
+
+function createUserData (count) {
+    const persons = [];
+    for (let i = 0; i < count; i += 1) {
+        const forename = faker.person.firstName();
+        const surname = faker.person.lastName();
+        const displayNameOptions = ["Not Provided", `${forename} ${surname}`];
+        persons.push({
+            _id: faker.string.uuid().replace(/-/g, ""),
+            email: faker.internet.email({ firstName: `inugami_test_data_${forename}`, lastName: surname }).toLowerCase(),
+            forename,
+            surname,
+            password: DEFAULT_PASSWORD,
+            display_name: displayNameOptions[Math.floor(Math.random() * 2)]
+        });
+    }
+    return persons;
+}
+
+function createAcspData (count) {
+    const acsps = [];
+    for (let i = 0; i < count; i += 1) {
+        const companyName = faker.company.name();
+        const acspNumber = `TSA${faker.string.numeric(3)}`;
+        acsps.push({
+            _id: acspNumber,
+            data: {
+                acsp_number: acspNumber,
+                name: companyName,
+                status: "active",
+                type: "limited-company",
+                links: {
+                    self: `/authorised-corporate-service-provider/${acspNumber}`
+                }
+            }
+        });
+    }
+    return acsps;
+}
+
+function createAcspMemberData (acsp, users) {
+    const roles = ["admin", "owner", "standard"];
+    return users.map((user) => ({
+        _id: faker.string.uuid().replace(/-/g, ""),
+        acsp_number: acsp._id,
+        user_id: user._id,
+        user_role: roles[Math.floor(Math.random() * 3)],
+        created_at: new Date("2023-07-03T11:55:23.649668000"),
+        added_at: new Date("2023-07-03T11:55:23.649668000"),
+        added_by: null,
+        removed_at: null,
+        removed_by: null,
+        status: "active",
+        etag: "b035bfdb99170913f11f73ac0d0e8afb9f15c13f",
+        version: 0,
+        _class: "uk.gov.companieshouse.acsp.manage.users.model.AcspMembersDao"
+    }));
+}
+
+main().catch(console.error);

--- a/tools/seed-acsp-data-mongo/package-lock.json
+++ b/tools/seed-acsp-data-mongo/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "seed-mongo",
+  "name": "seed-acsp-data-mongo",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "seed-mongo",
+      "name": "seed-acsp-data-mongo",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/tools/seed-acsp-data-mongo/package-lock.json
+++ b/tools/seed-acsp-data-mongo/package-lock.json
@@ -1,0 +1,167 @@
+{
+  "name": "seed-mongo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "seed-mongo",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@faker-js/faker": "^8.4.1",
+        "mongodb": "^6.8.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.8.tgz",
+      "integrity": "sha512-qKwC/M/nNNaKUBMQ0nuzm47b7ZYWQHN3pcXq4IIcoSBc2hOIrflAxJduIvvqmhoz3gR2TacTAs8vlsCVPkiEdQ==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
+      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
+    "node_modules/mongodb": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
+      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/tools/seed-acsp-data-mongo/package.json
+++ b/tools/seed-acsp-data-mongo/package.json
@@ -1,0 +1,16 @@
+{
+  "type": "module",
+  "name": "seed-acsp-data-mongo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@faker-js/faker": "^8.4.1",
+    "mongodb": "^6.8.0"
+  }
+}


### PR DESCRIPTION
Add MongoDB seed tool for ACSP test data

- Generates fake users, ACSP profiles, and members
- Configurable via env vars and config file
- Supports multiple MongoDB environments
- Located in tools/seed-acsp-data-mongo

Originally from https://github.com/bmchugh-ch - but modified to work with `acsp_profile.acsp_profile`.