### PR TITLE
IDVA6-1961 Redirect View And Manage Users

### DIFF
--- a/src/middleware/navigationMiddleware.ts
+++ b/src/middleware/navigationMiddleware.ts
@@ -56,6 +56,16 @@ export const NAVIGATION: Navigation = {
         allowedReferers: [constants.CHECK_EDIT_MEMBER_ROLE_DETAILS_FULL_URL, constants.CONFIRMATION_MEMBER_ROLE_EDITED_FULL_URL],
         redirectTo: constants.MANAGE_USERS_FULL_URL,
         allowedUserRoles: [UserRole.OWNER, UserRole.ADMIN]
+    },
+    [constants.VIEW_USERS_FULL_URL]: {
+        allowedReferers: [],
+        redirectTo: constants.MANAGE_USERS_FULL_URL,
+        allowedUserRoles: [UserRole.STANDARD]
+    },
+    [constants.MANAGE_USERS_FULL_URL]: {
+        allowedReferers: [],
+        redirectTo: constants.VIEW_USERS_FULL_URL,
+        allowedUserRoles: [UserRole.ADMIN, UserRole.OWNER]
     }
 };
 
@@ -70,8 +80,17 @@ export const navigationMiddleware = (req: Request, res: Response, next: NextFunc
         currentPath = constants.CHANGE_MEMBER_ROLE_BASE;
     }
 
+    if (currentPath.startsWith(constants.VIEW_USERS_FULL_URL)) {
+        currentPath = constants.VIEW_USERS_FULL_URL;
+    }
+
+    if (currentPath.startsWith(constants.MANAGE_USERS_FULL_URL)) {
+        currentPath = constants.MANAGE_USERS_FULL_URL;
+    }
+
     if (!NAVIGATION[currentPath]) {
         logger.info("navigation not found for the current path.");
+        logger.info(currentPath);
         return next();
     }
 

--- a/test/src/middleware/navigation.middleware.test.ts
+++ b/test/src/middleware/navigation.middleware.test.ts
@@ -80,6 +80,12 @@ describe("navigiationMiddleware", () => {
             url: "/authorised-agent/confirmation-member-role-edited",
             referer: "/authorised-agent/any-referer",
             user: ""
+        },
+        {
+            description: "should redirect admin user to manage users from view users",
+            url: "/authorised-agent/view-users",
+            referer: "/authorised-agent/any-referer",
+            user: adminUser
         }
     ];
 
@@ -202,6 +208,18 @@ describe("navigiationMiddleware", () => {
             url: "/authorised-agent/confirmation-member-role-edited",
             referer: "/authorised-agent/confirmation-member-role-edited",
             user: adminUser
+        },
+        {
+            description: "should allow standard user to access view users",
+            url: "/authorised-agent/view-users",
+            referer: "/authorised-agent/any-referer",
+            user: standardUser
+        },
+        {
+            description: "should redirect admin user to manage users",
+            url: "/authorised-agent/manage-users",
+            referer: "/authorised-agent/any-referer",
+            user: adminUser
         }
     ];
 
@@ -233,6 +251,23 @@ describe("navigiationMiddleware", () => {
         const request = mockRequest();
         const response = mockResponse();
         request.originalUrl = "/authorised-agent/add-user";
+        request.headers.referer = "/authorised-agent/any-referer";
+        getExtraDataSpy.mockReturnValue(standardUser);
+
+        // When
+        navigationMiddleware(request, response, mockedNext);
+
+        // Then
+        expect(mockedNext).not.toHaveBeenCalled();
+        expect(response.redirect).toHaveBeenCalledWith("/authorised-agent/view-users");
+    });
+
+    it("should redirect to view-users and not allow a standard user to access manage user page", () => {
+        // Given
+        const mockedNext = jest.fn();
+        const request = mockRequest();
+        const response = mockResponse();
+        request.originalUrl = "/authorised-agent/manage-users";
         request.headers.referer = "/authorised-agent/any-referer";
         getExtraDataSpy.mockReturnValue(standardUser);
 

--- a/test/src/middleware/navigation.middleware.test.ts
+++ b/test/src/middleware/navigation.middleware.test.ts
@@ -216,7 +216,7 @@ describe("navigiationMiddleware", () => {
             user: standardUser
         },
         {
-            description: "should redirect admin user to manage users",
+            description: "should allow admin user to access manage users",
             url: "/authorised-agent/manage-users",
             referer: "/authorised-agent/any-referer",
             user: adminUser


### PR DESCRIPTION
**JIRA LINK**
https://companieshouse.atlassian.net/browse/IDVA6-1961

**Description**
Added redirect for view and manage users.
Admin / account owners are automatically redirected from the view-users page (to the manage-users page) .
Standard users are redirected to view users when trying to access manage users.

**Unit test**
Updated navigation.middleware.test.ts