### PR TITLE
IDVA6-2069-Investigate and Fixing Integration Test Memory Leaks Warnings

### DIFF
--- a/test/src/app.test.ts
+++ b/test/src/app.test.ts
@@ -4,6 +4,8 @@ import app from "../../src/app";
 import { NextFunction, Request, Response } from "express";
 import * as constants from "../../src/lib/constants";
 
+jest.mock("../../src/lib/Logger");
+
 const router = supertest(app);
 const url = "/authorised-agent/";
 

--- a/test/src/routers/controllers/addUserController.test.ts
+++ b/test/src/routers/controllers/addUserController.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../../../mocks/acsp.members.mock";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 const url = "/authorised-agent/add-user";
 

--- a/test/src/routers/controllers/cannotAddUserController.test.ts
+++ b/test/src/routers/controllers/cannotAddUserController.test.ts
@@ -7,6 +7,8 @@ import * as enCommon from "../../../../locales/en/common.json";
 import { loggedAccountOwnerAcspMembership } from "../../../mocks/acsp.members.mock";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/cannot-add-user";

--- a/test/src/routers/controllers/checkEditMemberRoleDetailsController.test.ts
+++ b/test/src/routers/controllers/checkEditMemberRoleDetailsController.test.ts
@@ -15,6 +15,8 @@ import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import { getUserRoleTag } from "../../../../src/lib/utils/viewUtils";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/check-edit-member-role-details";

--- a/test/src/routers/controllers/checkMemberDetailsController.test.ts
+++ b/test/src/routers/controllers/checkMemberDetailsController.test.ts
@@ -10,6 +10,8 @@ import { loggedAccountOwnerAcspMembership } from "../../../mocks/acsp.members.mo
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 const getLoggedInUserEmailSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedInUserEmail");
 

--- a/test/src/routers/controllers/confirmationMemberAdded.test.ts
+++ b/test/src/routers/controllers/confirmationMemberAdded.test.ts
@@ -13,6 +13,8 @@ import { loggedAccountOwnerAcspMembership } from "../../../mocks/acsp.members.mo
 import { getUserRoleTag } from "../../../../src/lib/utils/viewUtils";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/confirmation-member-added";

--- a/test/src/routers/controllers/confirmationMemberRoleEditedController.test.ts
+++ b/test/src/routers/controllers/confirmationMemberRoleEditedController.test.ts
@@ -17,6 +17,8 @@ import * as cy from "../../../../locales/cy/confirmation-member-role-edited.json
 import * as enCommon from "../../../../locales/en/common.json";
 import * as cyCommon from "../../../../locales/cy/common.json";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/confirmation-member-role-edited";

--- a/test/src/routers/controllers/csrErrorController.test.ts
+++ b/test/src/routers/controllers/csrErrorController.test.ts
@@ -7,6 +7,8 @@ import * as getTranslationsForView from "../../../../src/lib/utils/translationUt
 import { CsrfError } from "@companieshouse/web-security-node";
 import * as contants from "../../../../src/lib/constants";
 
+jest.mock("../../../../src/lib/Logger");
+
 const mockGetTranslationsForView = jest.spyOn(getTranslationsForView, "getTranslationsForView");
 
 logger.error = jest.fn();

--- a/test/src/routers/controllers/dashboardController.test.ts
+++ b/test/src/routers/controllers/dashboardController.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../../../mocks/acsp.members.mock";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 const url = "/authorised-agent/";
 

--- a/test/src/routers/controllers/editMemberRoleController.test.ts
+++ b/test/src/routers/controllers/editMemberRoleController.test.ts
@@ -19,6 +19,8 @@ import { Membership } from "../../../../src/types/membership";
 import * as acspMemberService from "../../../../src/services/acspMemberService";
 import { when } from "jest-when";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/edit-member-role";

--- a/test/src/routers/controllers/healthCheckContorller.test.ts
+++ b/test/src/routers/controllers/healthCheckContorller.test.ts
@@ -2,6 +2,8 @@ import mocks from "../../../mocks/all.middleware.mock";
 import app from "../../../../src/app";
 import supertest from "supertest";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 const url = "/authorised-agent/healthcheck";
 

--- a/test/src/routers/controllers/httpErrorController.test.ts
+++ b/test/src/routers/controllers/httpErrorController.test.ts
@@ -7,6 +7,8 @@ import { NextFunction } from "express";
 import logger from "../../../../src/lib/Logger";
 import * as getTranslationsForView from "../../../../src/lib/utils/translationUtils";
 
+jest.mock("../../../../src/lib/Logger");
+
 const mockGetTranslationsForView = jest.spyOn(getTranslationsForView, "getTranslationsForView");
 
 logger.errorRequest = jest.fn();

--- a/test/src/routers/controllers/manageUsersController.pagination.test.ts
+++ b/test/src/routers/controllers/manageUsersController.pagination.test.ts
@@ -24,6 +24,8 @@ import { when } from "jest-when";
 import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import * as enCommon from "../../../../locales/en/common.json";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 const baseUrl = "/authorised-agent/manage-users";
 const getAcspMembershipsSpy: jest.SpyInstance = jest.spyOn(acspMemberService, "getAcspMemberships");

--- a/test/src/routers/controllers/manageUsersController.search.test.ts
+++ b/test/src/routers/controllers/manageUsersController.search.test.ts
@@ -12,6 +12,8 @@ import {
 } from "../../../mocks/acsp.members.mock";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/manage-users";

--- a/test/src/routers/controllers/manageUsersController.test.ts
+++ b/test/src/routers/controllers/manageUsersController.test.ts
@@ -18,6 +18,8 @@ import {
     getDisplayNameOrNotProvided
 } from "../../../../src/routers/controllers/manageUsersController";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/manage-users";

--- a/test/src/routers/controllers/removeUserCheckDetailsController.test.ts
+++ b/test/src/routers/controllers/removeUserCheckDetailsController.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../../../mocks/user.mock";
 import { when } from "jest-when";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/remove-member/";

--- a/test/src/routers/controllers/removeUserSuccessController.test.ts
+++ b/test/src/routers/controllers/removeUserSuccessController.test.ts
@@ -10,6 +10,8 @@ import { setExtraData } from "../../../../src/lib/utils/sessionUtils";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/confirmation-member-removed";

--- a/test/src/routers/controllers/stopPageAddOwnerControllerGet.test.ts
+++ b/test/src/routers/controllers/stopPageAddOwnerControllerGet.test.ts
@@ -12,6 +12,8 @@ import { UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/t
 import { adminUserRoleChangeDataMock } from "../../../mocks/user.mock";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/stop-page-add-account-owner";

--- a/test/src/routers/controllers/stopPageController.test.ts
+++ b/test/src/routers/controllers/stopPageController.test.ts
@@ -3,6 +3,8 @@ import supertest from "supertest";
 import app from "../../../../src/app";
 import * as en from "../../../../locales/en/service-unavailable.json";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 const url = "/authorised-agent/something-went-wrong";
 

--- a/test/src/routers/controllers/tryAddingUserController.test.ts
+++ b/test/src/routers/controllers/tryAddingUserController.test.ts
@@ -19,6 +19,7 @@ import { session } from "../../../mocks/session.middleware.mock";
 
 jest.mock("../../../../src/services/acspMemberService");
 jest.mock("../../../../src/services/userAccountService");
+jest.mock("../../../../src/lib/Logger");
 
 const router = supertest(app);
 const url = "/authorised-agent/try-adding-user";

--- a/test/src/routers/controllers/tryEditMemberRoleController.test.ts
+++ b/test/src/routers/controllers/tryEditMemberRoleController.test.ts
@@ -6,6 +6,8 @@ import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import * as acspMemberService from "../../../../src/services/acspMemberService";
 import * as constants from "../../../../src/lib/constants";
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/authorised-agent/try-edit-member-role";

--- a/test/src/routers/controllers/tryRemovingUserController.test.ts
+++ b/test/src/routers/controllers/tryRemovingUserController.test.ts
@@ -8,6 +8,8 @@ import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import * as acspMemberService from "../../../../src/services/acspMemberService";
 import { session } from "../../../mocks/session.middleware.mock";
 
+jest.mock("../../../../src/lib/Logger");
+
 const getLoggedUserAcspMembershipSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedUserAcspMembership");
 const loggedInUserMembership = {
     id: "123;",

--- a/test/src/routers/router.test.ts
+++ b/test/src/routers/router.test.ts
@@ -2,6 +2,8 @@ import mocks from "../../mocks/all.middleware.mock";
 import supertest from "supertest";
 import app from "../../../src/app";
 
+jest.mock("../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const url = "/dummy";


### PR DESCRIPTION
Investigated and fixing integration test memory leaks warnings by mocking the Logger using Jest.
This warnings was appearing in the console/terminals and this PR fixes it and it no longer shows the warnings of the terminal/console.

![image](https://github.com/user-attachments/assets/82f2b050-9dd9-4eb3-bc97-a39cdb6d705a)


`(node:34503) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)`