### PR TITLE
IDVA6-2161 Save manage user search results to the session

### DIFF
--- a/src/routers/controllers/manageUsersController.ts
+++ b/src/routers/controllers/manageUsersController.ts
@@ -100,8 +100,7 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
                     displayNameOrEmail: getDisplayNameOrEmail(member)
                 }));
 
-                const existingUsers: Membership[] = getExtraData(req.session, constants.MANAGE_USERS_MEMBERSHIP) || [];
-                setExtraData(req.session, constants.MANAGE_USERS_MEMBERSHIP, [...existingUsers, ...foundMember]);
+                setExtraData(req.session, constants.MANAGE_USERS_MEMBERSHIP, foundMember);
 
                 const memberData = getUserTableData(foundUser.items, translations, userRole !== UserRole.STANDARD, userRole !== UserRole.STANDARD, req.lang);
                 switch (foundUser.items[0].userRole) {

--- a/src/routers/controllers/manageUsersController.ts
+++ b/src/routers/controllers/manageUsersController.ts
@@ -4,7 +4,7 @@ import { getTranslationsForView } from "../../lib/utils/translationUtils";
 import { AnyRecord, MemberRawViewData, PageNumbers, PageQueryParams } from "../../types/utilTypes";
 import { TableEntry } from "../../types/viewTypes";
 import { getHiddenText, getLink } from "../../lib/utils/viewUtils";
-import { setExtraData, getLoggedUserAcspMembership, deleteExtraData } from "../../lib/utils/sessionUtils";
+import { getExtraData, setExtraData, getLoggedUserAcspMembership, deleteExtraData } from "../../lib/utils/sessionUtils";
 import { AcspMembership, UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import { getAcspMemberships, membershipLookup } from "../../services/acspMemberService";
 import { sanitizeUrl } from "@braintree/sanitize-url";
@@ -14,6 +14,7 @@ import { getChangeMemberRoleFullUrl, getRemoveMemberCheckDetailsFullUrl } from "
 import { buildPaginationElement, getCurrentPageNumber, setLangForPagination, stringToPositiveInteger } from "../../lib/helpers/buildPaginationHelper";
 import { validatePageNumber } from "../../lib/validation/page.number.validation";
 import { validateActiveTabId } from "../../lib/validation/string.validation";
+import { Membership } from "../../types/membership";
 
 export const manageUsersControllerGet = async (req: Request, res: Response): Promise<void> => {
     const viewData = await getViewData(req);
@@ -86,6 +87,22 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
             const foundUser = await membershipLookup(req, acspNumber, search);
             if (foundUser.items.length > 0) {
                 setTabIds(viewData, foundUser.items[0].userRole);
+
+                const foundMember = [
+                    foundUser.items[0]
+                ].map(member => ({
+                    id: member.id,
+                    userId: member.userId,
+                    userEmail: member.userEmail,
+                    acspNumber: member.acspNumber,
+                    userRole: member.userRole,
+                    userDisplayName: getDisplayNameOrNotProvided(req.lang, member),
+                    displayNameOrEmail: getDisplayNameOrEmail(member)
+                }));
+
+                const existingUsers: Membership[] = getExtraData(req.session, constants.MANAGE_USERS_MEMBERSHIP) || [];
+                setExtraData(req.session, constants.MANAGE_USERS_MEMBERSHIP, [...existingUsers, ...foundMember]);
+
                 const memberData = getUserTableData(foundUser.items, translations, userRole !== UserRole.STANDARD, userRole !== UserRole.STANDARD, req.lang);
                 switch (foundUser.items[0].userRole) {
                 case UserRole.OWNER:

--- a/src/routers/controllers/manageUsersController.ts
+++ b/src/routers/controllers/manageUsersController.ts
@@ -4,7 +4,7 @@ import { getTranslationsForView } from "../../lib/utils/translationUtils";
 import { AnyRecord, MemberRawViewData, PageNumbers, PageQueryParams } from "../../types/utilTypes";
 import { TableEntry } from "../../types/viewTypes";
 import { getHiddenText, getLink } from "../../lib/utils/viewUtils";
-import { getExtraData, setExtraData, getLoggedUserAcspMembership, deleteExtraData } from "../../lib/utils/sessionUtils";
+import { setExtraData, getLoggedUserAcspMembership, deleteExtraData } from "../../lib/utils/sessionUtils";
 import { AcspMembership, UserRole } from "private-api-sdk-node/dist/services/acsp-manage-users/types";
 import { getAcspMemberships, membershipLookup } from "../../services/acspMemberService";
 import { sanitizeUrl } from "@braintree/sanitize-url";
@@ -14,7 +14,6 @@ import { getChangeMemberRoleFullUrl, getRemoveMemberCheckDetailsFullUrl } from "
 import { buildPaginationElement, getCurrentPageNumber, setLangForPagination, stringToPositiveInteger } from "../../lib/helpers/buildPaginationHelper";
 import { validatePageNumber } from "../../lib/validation/page.number.validation";
 import { validateActiveTabId } from "../../lib/validation/string.validation";
-import { Membership } from "../../types/membership";
 
 export const manageUsersControllerGet = async (req: Request, res: Response): Promise<void> => {
     const viewData = await getViewData(req);
@@ -82,6 +81,16 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
         viewData.search = search;
     }
 
+    const formatMember = (member: AcspMembership) => ({
+        id: member.id,
+        userId: member.userId,
+        userEmail: member.userEmail,
+        acspNumber: member.acspNumber,
+        userRole: member.userRole,
+        userDisplayName: getDisplayNameOrNotProvided(req.lang, member),
+        displayNameOrEmail: getDisplayNameOrEmail(member)
+    });
+
     if (isSearchValid && search) {
         try {
             const foundUser = await membershipLookup(req, acspNumber, search);
@@ -90,15 +99,7 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
 
                 const foundMember = [
                     foundUser.items[0]
-                ].map(member => ({
-                    id: member.id,
-                    userId: member.userId,
-                    userEmail: member.userEmail,
-                    acspNumber: member.acspNumber,
-                    userRole: member.userRole,
-                    userDisplayName: getDisplayNameOrNotProvided(req.lang, member),
-                    displayNameOrEmail: getDisplayNameOrEmail(member)
-                }));
+                ].map(formatMember);
 
                 setExtraData(req.session, constants.MANAGE_USERS_MEMBERSHIP, foundMember);
 
@@ -141,15 +142,7 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
             ...ownerMemberRawViewData.memberships,
             ...adminMemberRawViewData.memberships,
             ...standardMemberRawViewData.memberships
-        ].map(member => ({
-            id: member.id,
-            userId: member.userId,
-            userEmail: member.userEmail,
-            acspNumber: member.acspNumber,
-            userRole: member.userRole,
-            userDisplayName: getDisplayNameOrNotProvided(req.lang, member),
-            displayNameOrEmail: getDisplayNameOrEmail(member)
-        }));
+        ].map(formatMember);
 
         setExtraData(req.session, constants.MANAGE_USERS_MEMBERSHIP, allMembersForThisAcsp);
     }

--- a/test/src/routers/controllers/manageUsersController.search.test.ts
+++ b/test/src/routers/controllers/manageUsersController.search.test.ts
@@ -21,6 +21,7 @@ const viewUserUrl = "/authorised-agent/view-users";
 const getAcspMembershipsSpy = jest.spyOn(acspMemberService, "getAcspMemberships");
 const membershipLookupSpy = jest.spyOn(acspMemberService, "membershipLookup");
 const getLoggedUserAcspMembershipSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedUserAcspMembership");
+const setExtraDataSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "setExtraData");
 
 describe("manageUsersControllerGet - search", () => {
 
@@ -71,6 +72,9 @@ describe("manageUsersControllerGet - search", () => {
         // When
         const response = await router.get(`${url}?search=${search}`);
         // Then
+        expect(setExtraDataSpy).toHaveBeenCalledTimes(1);
+        expect(setExtraDataSpy).toHaveBeenCalledWith(expect.anything(), "manageUsersMembership", expect.anything());
+
         expect(response.text).toContain(administratorAcspMembership.userEmail);
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
         expect(response.text).not.toContain(en.you_have_no_admin_users);
@@ -86,6 +90,7 @@ describe("manageUsersControllerGet - search", () => {
         // When
         const response = await router.get(`${viewUserUrl}?search=${search}`);
         // Then
+        expect(setExtraDataSpy).toHaveBeenCalledTimes(1);
         expect(response.text).toContain(standardUserAcspMembership.userEmail);
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
         expect(response.text).toContain(en.you_have_no_admin_users);

--- a/test/src/routers/controllers/manageUsersController.search.test.ts
+++ b/test/src/routers/controllers/manageUsersController.search.test.ts
@@ -74,7 +74,6 @@ describe("manageUsersControllerGet - search", () => {
         // Then
         expect(setExtraDataSpy).toHaveBeenCalledTimes(1);
         expect(setExtraDataSpy).toHaveBeenCalledWith(expect.anything(), "manageUsersMembership", expect.anything());
-
         expect(response.text).toContain(administratorAcspMembership.userEmail);
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
         expect(response.text).not.toContain(en.you_have_no_admin_users);
@@ -91,6 +90,8 @@ describe("manageUsersControllerGet - search", () => {
         const response = await router.get(`${viewUserUrl}?search=${search}`);
         // Then
         expect(setExtraDataSpy).toHaveBeenCalledTimes(1);
+        expect(setExtraDataSpy).toHaveBeenCalledWith(expect.anything(), "manageUsersMembership", expect.anything());
+
         expect(response.text).toContain(standardUserAcspMembership.userEmail);
         expect(response.text).not.toContain(en.errors_enter_an_email_address_in_the_correct_format);
         expect(response.text).toContain(en.you_have_no_admin_users);


### PR DESCRIPTION
**Link to Jira**
https://companieshouse.atlassian.net/browse/IDVA6-2162

**Description**
When  searching for a user (who is not on the most recent manage users page) and you try to remove or change role for the user the page errors as this user (who was searched for) is not found in the session.

This PR fixes the above issue by ensuring any searched for user is saved to the session.
