### PR TITLE
IDVA6-2288 Bug: Standard users - pagination buttons should link to view-users not manage-users

### DIFF
--- a/src/routers/controllers/manageUsersController.ts
+++ b/src/routers/controllers/manageUsersController.ts
@@ -125,9 +125,9 @@ export const getViewData = async (req: Request): Promise<AnyRecord> => {
         viewData.search = search;
     } else {
         const [ownerMemberRawViewData, adminMemberRawViewData, standardMemberRawViewData] = await Promise.all([
-            getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.OWNER, constants.ACCOUNT_OWNERS_TAB_ID, translations),
-            getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.ADMIN, constants.ADMINISTRATORS_TAB_ID, translations),
-            getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.STANDARD, constants.STANDARD_USERS_TAB_ID, translations)
+            getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.OWNER, constants.ACCOUNT_OWNERS_TAB_ID, translations, userRole),
+            getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.ADMIN, constants.ADMINISTRATORS_TAB_ID, translations, userRole),
+            getMemberRawViewData(req, acspNumber, pageNumbers, UserRole.STANDARD, constants.STANDARD_USERS_TAB_ID, translations, userRole)
         ]);
 
         viewData.accountOwnersTableData = getUserTableData(ownerMemberRawViewData.memberships, translations, userRole === UserRole.OWNER, userRole === UserRole.OWNER, req.lang);
@@ -207,7 +207,7 @@ const setTabIds = (viewData: AnyRecord, userRole: UserRole) => {
     }
 };
 
-const getMemberRawViewData = async (req: Request, acspNumber: string, pageNumbers: PageNumbers, userRole: UserRole, activeTabId: string, lang: AnyRecord): Promise<MemberRawViewData> => {
+const getMemberRawViewData = async (req: Request, acspNumber: string, pageNumbers: PageNumbers, userRole: UserRole, activeTabId: string, lang: AnyRecord, loggedInUserRole: UserRole): Promise<MemberRawViewData> => {
     let pageNumber = getCurrentPageNumber(pageNumbers, userRole);
     let memberships = await getAcspMemberships(req, acspNumber, false, pageNumber - 1, constants.ITEMS_PER_PAGE_DEFAULT, [userRole]);
     if (!validatePageNumber(pageNumber, memberships.totalPages)) {
@@ -219,7 +219,7 @@ const getMemberRawViewData = async (req: Request, acspNumber: string, pageNumber
     const memberViewData: MemberRawViewData = { memberships: memberships.items, pageNumber };
 
     if (memberships.totalPages > 1) {
-        const pagination = buildPaginationElement(pageNumbers, userRole, memberships.totalPages, constants.MANAGE_USERS_FULL_URL, activeTabId, lang);
+        const pagination = buildPaginationElement(pageNumbers, userRole, memberships.totalPages, getCancelSearchHref(loggedInUserRole), activeTabId, lang);
         setLangForPagination(pagination, lang);
         memberViewData.pagination = pagination;
     }


### PR DESCRIPTION
When standard users are logged in and they click on pagination buttons (next, previous, 1..2) they are incorrectly redirected to the manage-users page rather than view-users.

Link to Jira
https://companieshouse.atlassian.net/browse/IDVA6-2288