### PR TITLE
IDVA6-2294 Disable tracking remove, add user goals for standard users

### DIFF
--- a/src/views/manage-users.njk
+++ b/src/views/manage-users.njk
@@ -285,8 +285,10 @@
         }
 
         function addGoalEventListeners() {
-            trackGoal("add-a-user-button", {{MATOMO_ADD_USER_GOAL_ID}});
-            trackRemoveButtons({{MATOMO_REMOVE_USER_GOAL_ID}});
+                {% if loggedInUserRole !== UserRole.STANDARD %}
+                trackGoal("add-a-user-button", {{ MATOMO_ADD_USER_GOAL_ID }});
+                trackRemoveButtons({{ MATOMO_REMOVE_USER_GOAL_ID }});
+                {% endif %}
         }
 
         if (document.readyState === "loading") {
@@ -296,6 +298,7 @@
         } else {
             addGoalEventListeners()
         }
+      
     </script>
 
 {% endblock %}


### PR DESCRIPTION
There is an error appearing in the browser logs when matomo tries to track the remove and add user goals and the logged in user is a standard user. 

This PR ensures that the event listeners are only added when the user is an admin or owner.

**Link to Jira**
https://companieshouse.atlassian.net/browse/IDVA6-2294