### PR TITLE
IDVA6-2396 - Continue Language Throughout Services

### DIFF
--- a/src/views/partials/dashboard/verify_someones_identity.njk
+++ b/src/views/partials/dashboard/verify_someones_identity.njk
@@ -20,10 +20,13 @@
             {{ lang.verifying_someones_identity }}
         </h2>
 
+        {% set languageFlag = "?lang=cy" if locale == "cy" else 
+            "?lang=en" %}
+
         <p class="govuk-body">
             {{lang.use_our_service_to}}
             <a class="govuk-link govuk-link--no-visited-state" 
-            href="{{youHaveVerifiedSomeonesIdentityLink}}"
+            href="{{youHaveVerifiedSomeonesIdentityLink}}{{languageFlag}}"
             >
                 {{lang.tell_companies_house_link_text}}
             </a>

--- a/test/src/routers/controllers/dashboardController.test.ts
+++ b/test/src/routers/controllers/dashboardController.test.ts
@@ -256,7 +256,7 @@ describe(`GET ${url}`, () => {
 
         // Then
         expect(decodedResponse).toContain(
-            `href="/tell-companies-house-you-have-verified-someones-identity"`
+            `href="/tell-companies-house-you-have-verified-someones-identity?lang=en"`
         );
     });
 });


### PR DESCRIPTION
Link to Jira:
https://companieshouse.atlassian.net/browse/IDVA6-2396

Changes:
- Added query string logic to "Verifying someone's identity" link to continue same language throughout service