### PR TITLE
IDVA6-2265 Survey Link Should Not Open New Tab

### DIFF
--- a/src/views/partials/__header.njk
+++ b/src/views/partials/__header.njk
@@ -28,7 +28,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div id="customer-insights-top-banner">
-            <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/csat-companieshouseservice/" target="_blank">
+            <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/csat-companieshouseservice/" target="_self">
                 {{lang.tell_us_what_you_think_of_companies_house}}
             </a>
         </div>


### PR DESCRIPTION
**Jira link:**
https://companieshouse.atlassian.net/browse/IDVA6-2265

**Changes:**
- Made changes so Tell us what you think of Companies House survey link should **not** open a new tab by changing target=_blank to target=_self.

<img width="931" alt="Screenshot 2025-04-14 at 16 27 52" src="https://github.com/user-attachments/assets/f60b927c-b88a-4a98-ad95-0209957a026b" />


![Screenshot 2025-04-14 at 16 31 17](https://github.com/user-attachments/assets/1d90cf2c-d71f-4f0e-8df5-a64c80ad2e89)


