### PR TITLE
SIV-524 Allow form submissions to gov.uk urls.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -84,13 +84,7 @@ const nonce: string = uuidv4();
 
 app.use(nocache());
 
-app.use((req, res, next) => {
-    if (req.path !== constants.TRY_REMOVING_USER_FULL_URL) {
-        helmet(prepareCSPConfig(nonce))(req, res, next);
-    } else {
-        next();
-    }
-});
+app.use(helmet(prepareCSPConfig(nonce)));
 
 app.use(`${constants.LANDING_URL}*`, sessionMiddleware);
 app.use(`${constants.LANDING_URL}*`, ensureSessionCookiePresentMiddleware);

--- a/src/middleware/content.security.policy.middleware.config.ts
+++ b/src/middleware/content.security.policy.middleware.config.ts
@@ -19,8 +19,8 @@ export const prepareCSPConfig = (nonce: string): HelmetOptions => {
                 connectSrc: [SELF, PIWIK_URL, CDN],
                 formAction: [
                     SELF,
-                    PIWIK_CHS_DOMAIN
-                ],
+                    PIWIK_CHS_DOMAIN,
+                    "https://*.gov.uk"],
                 scriptSrc: [
                     NONCE,
                     CDN,

--- a/src/routers/controllers/tryRemovingUserController.ts
+++ b/src/routers/controllers/tryRemovingUserController.ts
@@ -33,7 +33,6 @@ export const tryRemovingUserControllerPost = async (req: Request, res: Response)
         acspLogger(req.session, tryRemovingUserControllerPost.name, "User has removed themselves, redirecting to sign out now ... ");
 
         res.set("Referrer-Policy", "origin");
-        res.removeHeader("Content-Security-Policy");
         return res.redirect(constants.SIGN_OUT_URL);
 
     } else {


### PR DESCRIPTION
**Link to Jira**
https://companieshouse.atlassian.net/browse/SIV-524

**Description**

When a user removes themselves from an ACSP we process the form and then redirect to the sign out page.
If the user is logged in via one login the sign out url redirects them to external gov.uk one login urls.
This was blocked due to our content security policy settings. This error was appearing in the browser -
Refused to send form data to url because it violates the following Content Security Policy directive: "form-action ...

To resolve this, the form-action directive now allows form submissions to https URIs ending in gov.uk.

