### PR TITLE
SIV-524 update CSP: allow http, https chs url form submissions, redirects

### DIFF
--- a/src/middleware/content.security.policy.middleware.config.ts
+++ b/src/middleware/content.security.policy.middleware.config.ts
@@ -7,6 +7,8 @@ export const prepareCSPConfig = (nonce: string): HelmetOptions => {
     const SELF = `'self'`;
     const NONCE = `'nonce-${nonce}'`;
     const ONE_YEAR_SECONDS = 31536000;
+    const CHS_URL = process.env.CHS_URL as string;
+    const HTTP_CHS_URL: string = CHS_URL.replace(/^https:\/\//, "http://");
 
     return {
         contentSecurityPolicy: {
@@ -20,7 +22,10 @@ export const prepareCSPConfig = (nonce: string): HelmetOptions => {
                 formAction: [
                     SELF,
                     PIWIK_CHS_DOMAIN,
-                    "https://*.gov.uk", "*"],
+                    "https://*.gov.uk",
+                    CHS_URL,
+                    HTTP_CHS_URL
+                ],
                 scriptSrc: [
                     NONCE,
                     CDN,


### PR DESCRIPTION
**Jira**
https://companieshouse.atlassian.net/browse/SIV-524

**Description**
After forms are submitted, the auth service sometimes redirects to HTTP urls, which is blocked by our CSP.
This PR updates the CSP to allow forms to submit and redirect to http://CHS_URL